### PR TITLE
Implement wc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,6 @@ members = [
     "whoami",
     "uname",
     "tty",
+    "wc",
     "yes"
 ]

--- a/wc/Cargo.toml
+++ b/wc/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "wc"
+version = "0.1.0"
+authors = ["silverweed <silverweed1991@gmail.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["yaml", "wrap_help"] }
+
+[build-dependencies]
+clap = { version = "^2.33.0", features = ["yaml"] }

--- a/wc/build.rs
+++ b/wc/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+use clap::{ App, Shell, load_yaml };
+
+fn main() {
+    let yaml = load_yaml!("src/wc.yml");
+    let mut app = App::from_yaml(yaml);
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        _ => return
+    };
+
+    app.gen_completions("wc", Shell::Zsh, out_dir.clone());
+    app.gen_completions("wc", Shell::Fish, out_dir.clone());
+    app.gen_completions("wc", Shell::Bash, out_dir.clone());
+    app.gen_completions("wc", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("wc", Shell::Elvish, out_dir);
+}

--- a/wc/src/main.rs
+++ b/wc/src/main.rs
@@ -45,17 +45,15 @@ fn main() {
         match result {
             Err(err) => eprintln!("wc: {}: {}", filename, err),
             Ok(result) => {
-                print_result(filename, &result);
+                println!("{}", get_formatted_result(filename, &result));
                 total_result = total_result.combine(result);
             }
         }
     }
 
     if filenames.len() > 1 {
-        print_result("total", &total_result);
+        println!("{}", get_formatted_result("total", &total_result));
     }
-
-    process::exit(0);
 }
 
 #[derive(Default)]
@@ -119,10 +117,6 @@ fn wc<R: Read>(stream: R, flags: u8) -> Result<WcResult, io::Error> {
     }
 
     Ok(result)
-}
-
-fn print_result(filename: &str, result: &WcResult) {
-    println!("{}", get_formatted_result(filename, result));
 }
 
 fn get_formatted_result(filename: &str, result: &WcResult) -> String {

--- a/wc/src/main.rs
+++ b/wc/src/main.rs
@@ -1,0 +1,158 @@
+use std::fs::File;
+use std::io::prelude::*;
+use std::io::{self, BufReader};
+use std::process;
+
+use clap::{load_yaml, App, ArgMatches};
+
+const PRINT_LINES: u8 = 0x1;
+const PRINT_WORDS: u8 = 0x2;
+const PRINT_CHARS: u8 = 0x4;
+const PRINT_BYTES: u8 = 0x8;
+const PRINT_MAX_LINE_LEN: u8 = 0x10;
+const DEFAULT_FLAGS: u8 = PRINT_LINES | PRINT_WORDS | PRINT_CHARS;
+
+fn main() {
+    let yaml = load_yaml!("wc.yml");
+    let matches = App::from_yaml(yaml).get_matches();
+
+    let filenames: Vec<String> = {
+        if let Some(values) = matches.values_of("FILE") {
+            let mut v = Vec::new();
+            for value in values {
+                v.push(value.to_owned());
+            }
+            v
+        } else {
+            vec![String::from("-")]
+        }
+    };
+
+    let flags = parse_flags(&matches);
+
+    for filename in &filenames {
+        let result = if filename == "-" {
+            let stdin = io::stdin();
+            wc(stdin.lock(), flags)
+        } else {
+            match File::open(filename) {
+                Ok(file) => wc(file, flags),
+                Err(err) => Err(err),
+            }
+        };
+
+        match result {
+            Err(err) => eprintln!("wc: {}: {}", filename, err),
+            Ok(result) => print_result(filename, &result),
+        }
+    }
+
+    process::exit(0);
+}
+
+#[derive(Default)]
+struct WcResult {
+    pub lines: u64,
+    pub words: u64,
+    pub chars: u64,
+    pub bytes: u64,
+    pub max_line_len: u32,
+    pub flags: u8,
+}
+
+fn wc<R: Read>(stream: R, flags: u8) -> Result<WcResult, io::Error> {
+    let reader = BufReader::new(stream);
+
+    let mut result = WcResult {
+        flags,
+        ..Default::default()
+    };
+
+    for line in reader.lines() {
+        let line = line?;
+
+        result.lines += 1;
+
+        let mut last_was_whitespace = true;
+        let mut n_chars_excluding_newline = 0;
+        for chr in line.chars() {
+            n_chars_excluding_newline += 1;
+
+            let is_whitespace = chr.is_whitespace();
+            if is_whitespace && !last_was_whitespace {
+                result.words += 1;
+            }
+            last_was_whitespace = is_whitespace;
+        }
+
+        // The max line length considers characters, not bytes.
+        result.max_line_len = result.max_line_len.max(n_chars_excluding_newline);
+
+        result.chars += u64::from(n_chars_excluding_newline) + 1;
+
+        if !last_was_whitespace {
+            result.words += 1;
+        }
+
+        result.bytes += line.len() as u64 + 1;
+    }
+
+    Ok(result)
+}
+
+fn print_result(filename: &str, result: &WcResult) {
+    let flags = result.flags;
+    let mut s = String::with_capacity(64);
+
+    // Order is: newline, word, character, byte, maximum line length.
+    if (flags & PRINT_LINES) != 0 {
+        s.push_str(&result.lines.to_string());
+        s.push(' ');
+    }
+    if (flags & PRINT_WORDS) != 0 {
+        s.push_str(&result.words.to_string());
+        s.push(' ');
+    }
+    if (flags & PRINT_CHARS) != 0 {
+        s.push_str(&result.chars.to_string());
+        s.push(' ');
+    }
+    if (flags & PRINT_BYTES) != 0 {
+        s.push_str(&result.bytes.to_string());
+        s.push(' ');
+    }
+    if (flags & PRINT_MAX_LINE_LEN) != 0 {
+        s.push_str(&result.max_line_len.to_string());
+        s.push(' ');
+    }
+
+    s.push_str(filename);
+
+    println!("{}", s);
+}
+
+fn parse_flags(matches: &ArgMatches<'_>) -> u8 {
+    let mut flags = 0;
+
+    if matches.is_present("bytes") {
+        flags |= PRINT_BYTES;
+    }
+    if matches.is_present("chars") {
+        flags |= PRINT_CHARS;
+    }
+    if matches.is_present("lines") {
+        flags |= PRINT_LINES;
+    }
+    if matches.is_present("max-line-length") {
+        flags |= PRINT_MAX_LINE_LEN;
+    }
+    if matches.is_present("words") {
+        flags |= PRINT_WORDS;
+    }
+
+    if flags == 0 {
+        DEFAULT_FLAGS
+    } else {
+        flags
+    }
+}

--- a/wc/src/wc.yml
+++ b/wc/src/wc.yml
@@ -1,30 +1,30 @@
 name: echo
 version: "0.0.0"
 author: Giacomo Parolini <silverweed1991@gmail.com>
-about: "Print newline, word and byte counts for each FILE, and a total line if more than one FILE is specified. A word is a non-zero-length sequence of characters delimited by white space.\n\nWith no FILE, or when FILE is -, read standard input."
+about: "Display newline, word and byte counts for each FILE, and a total line if more than one FILE is specified. A word is a non-zero-length sequence of characters delimited by white space.\n\nWith no FILE, or when FILE is -, read standard input."
 args:
     - FILE:
         help: One or more file names.
-        required: false 
+        required: false
         multiple: true
     - bytes:
         long: bytes
         short: c
-        help: print the byte counts
+        help: Display the byte counts
     - chars:
         long: chars
         short: m
-        help: print the character counts
+        help: Display the character counts
     - lines:
         long: lines
         short: l
-        help: print the newline counts
+        help: Display the newline counts
     - max-line-length:
         long: max-line-length
         short: L
-        help: print the maximum display width
+        help: Display the maximum display width
     - words:
         long: words
         short: w
-        help: print the word counts
+        help: Display the word counts
 

--- a/wc/src/wc.yml
+++ b/wc/src/wc.yml
@@ -1,0 +1,30 @@
+name: echo
+version: "0.0.0"
+author: Giacomo Parolini <silverweed1991@gmail.com>
+about: "Print newline, word and byte counts for each FILE, and a total line if more than one FILE is specified. A word is a non-zero-length sequence of characters delimited by white space.\n\nWith no FILE, or when FILE is -, read standard input."
+args:
+    - FILE:
+        help: One or more file names.
+        required: false 
+        multiple: true
+    - bytes:
+        long: bytes
+        short: c
+        help: print the byte counts
+    - chars:
+        long: chars
+        short: m
+        help: print the character counts
+    - lines:
+        long: lines
+        short: l
+        help: print the newline counts
+    - max-line-length:
+        long: max-line-length
+        short: L
+        help: print the maximum display width
+    - words:
+        long: words
+        short: w
+        help: print the word counts
+

--- a/wc/src/wc.yml
+++ b/wc/src/wc.yml
@@ -27,4 +27,8 @@ args:
         long: words
         short: w
         help: Display the word counts
+    - pretty:
+        long: pretty
+        short: p
+        help: Output results in a more human readable format
 


### PR DESCRIPTION
Addresses #6.

Main differences from GNU `wc`:
- missing `--files0-from` flag
- output numbers are always separated by a single space, rather than spaced in fancy ways.

I included a single unit test, but more may be added with ease if needed.