### PR TITLE
Env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "basename",
     "dirname",
     "echo",
+	"env",
     "false",
     "groups",
     "id",

--- a/env/Cargo.toml
+++ b/env/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "env"
+version = "0.0.1"
+authors = ["Federico Ponzi <federico.ponzi92@gmail.com>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["yaml", "wrap_help"] }
+
+[build-dependencies]
+clap = { version = "^2.33.0", features = ["yaml"] }

--- a/env/build.rs
+++ b/env/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+use clap::{ App, Shell, load_yaml };
+
+fn main() {
+    let yaml = load_yaml!("src/env.yml");
+    let mut app = App::from_yaml(yaml);
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        _ => return
+    };
+
+    app.gen_completions("env", Shell::Zsh, out_dir.clone());
+    app.gen_completions("env", Shell::Fish, out_dir.clone());
+    app.gen_completions("env", Shell::Bash, out_dir.clone());
+    app.gen_completions("env", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("env", Shell::Elvish, out_dir);
+}

--- a/env/build.rs
+++ b/env/build.rs
@@ -1,6 +1,6 @@
 use std::env;
 
-use clap::{ App, Shell, load_yaml };
+use clap::{load_yaml, App, Shell};
 
 fn main() {
     let yaml = load_yaml!("src/env.yml");
@@ -8,7 +8,7 @@ fn main() {
 
     let out_dir = match env::var("OUT_DIR") {
         Ok(dir) => dir,
-        _ => return
+        _ => return,
     };
 
     app.gen_completions("env", Shell::Zsh, out_dir.clone());

--- a/env/src/env.yml
+++ b/env/src/env.yml
@@ -1,9 +1,8 @@
 name: echo
 version: "0.0.0"
 author: Federico Ponzi <federico.ponzi92@gmail.com>
-about: "
-     env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]\n\n
-    Set each NAME to VALUE in the environment and run COMMAND.:\n\n"
+about: "Set environment and execute command, or print environment\n\n
+The env utility executes another [COMMAND] after modifying the environment as specified on the command line. Each [NAME=VALUE] option specifies the setting of an environment variable, name, with a value of value.  All such environment variables are set before the [COMMAND] is executed."
 args:
     - OPTIONS:
         help: Environement variables in the form of NAME=VALUE and the COMMAND to run with its arguments.
@@ -12,11 +11,11 @@ args:
         long: ignore-environment
         short: i
         help: start with an empty environment
-    - NULL_EOL:
+    - "NULL":
         long: "null"
         short: "0"
         help: end each output line with NUL, not newline
-    - REMOVE_VAR:
+    - UNSET:
         long: unset
         short: u
         takes_value: true

--- a/env/src/env.yml
+++ b/env/src/env.yml
@@ -1,29 +1,24 @@
 name: echo
 version: "0.0.0"
-author: Eric Shimizu Karbstein <gr41.j4ck@gmail.com>
-about: "Echo the STRING(s) to standard output.\nIf -e is in effect, the following sequences are recognized:\n\n
-\\\\      backslash\n
-\\a      alert (BEL)\n
-\\b      backspace\n
-\\c      produce no further output\n
-\\e      escape\n
-\\f      form feed\n
-\\n      new line\n
-\\r      carriage return\n
-\\t      horizontal tab\n
-\\v      vertical tab\n
-\\0NNN   byte with octal value NNN (1 to 3 digits)\n
-\\xHH    byte with hexadecimal value HH (1 to 2 digits)"
+author: Federico Ponzi <federico.ponzi92@gmail.com>
+about: "
+     env [OPTION]... [-] [NAME=VALUE]... [COMMAND [ARG]...]\n\n
+    Set each NAME to VALUE in the environment and run COMMAND.:\n\n"
 args:
-    - STRING:
-        help: The text to be printed.
-        required: true
+    - OPTIONS:
+        help: Environement variables in the form of NAME=VALUE and the COMMAND to run with its arguments.
         multiple: true
-    - escape:
-        long: backslash-escapes
-        short: e
-        help: Enable interpretation of backslash escapes.
-    - no_newline:
-        long: no-newline
-        short: n
-        help: Do not output the trailing newline.
+    - IGNORE_ENVIRONMENT:
+        long: ignore-environment
+        short: i
+        help: start with an empty environment
+    - NULL_EOL:
+        long: "null"
+        short: "0"
+        help: end each output line with NUL, not newline
+    - REMOVE_VAR:
+        long: unset
+        short: u
+        takes_value: true
+        multiple: true
+        help: remove variable from the environment

--- a/env/src/env.yml
+++ b/env/src/env.yml
@@ -1,0 +1,29 @@
+name: echo
+version: "0.0.0"
+author: Eric Shimizu Karbstein <gr41.j4ck@gmail.com>
+about: "Echo the STRING(s) to standard output.\nIf -e is in effect, the following sequences are recognized:\n\n
+\\\\      backslash\n
+\\a      alert (BEL)\n
+\\b      backspace\n
+\\c      produce no further output\n
+\\e      escape\n
+\\f      form feed\n
+\\n      new line\n
+\\r      carriage return\n
+\\t      horizontal tab\n
+\\v      vertical tab\n
+\\0NNN   byte with octal value NNN (1 to 3 digits)\n
+\\xHH    byte with hexadecimal value HH (1 to 2 digits)"
+args:
+    - STRING:
+        help: The text to be printed.
+        required: true
+        multiple: true
+    - escape:
+        long: backslash-escapes
+        short: e
+        help: Enable interpretation of backslash escapes.
+    - no_newline:
+        long: no-newline
+        short: n
+        help: Do not output the trailing newline.

--- a/env/src/main.rs
+++ b/env/src/main.rs
@@ -1,30 +1,39 @@
-use std::{
-    io::{self, Write},
-    iter::Peekable,
-    process,
-    str::Chars,
-};
+use std::collections::HashMap;
+use std::process;
+use std::process::Command;
+use std::{env, io};
 
 use clap::{load_yaml, App};
 
 fn main() {
     let yaml = load_yaml!("env.yml");
     let matches = App::from_yaml(yaml).get_matches();
-
-    let strings: Vec<String> = {
-        // Safe to unwrap since we said it is required on clap yaml
-        let values = matches.values_of("STRING").unwrap();
-        let mut v = Vec::new();
-        for value in values {
-            v.push(value.to_owned());
+    let mut kv = HashMap::new();
+    let mut cmd = Vec::new();
+    matches.values_of("OPTIONS").map(|m| {
+        for word in m {
+            let word_str: String = word.to_owned();
+            match word_str.find('=') {
+                Some(index) => {
+                    let (k, v) = word_str.split_at(index);
+                    kv.insert(k.to_owned(), v.get(1..).unwrap_or("").to_owned());
+                }
+                None => {
+                    cmd.push(word_str);
+                }
+            }
         }
-        v
-    };
-
-    match echo(
-        strings,
-        matches.is_present("escape"),
-        matches.is_present("no_newline"),
+    });
+    let mut unset_keys = Vec::new();
+    matches.values_of("REMOVE_VAR").map(|keys| {
+        keys.for_each(|k| unset_keys.push(k.to_owned()));
+    });
+    match env(
+        kv,
+        matches.is_present("IGNORE_ENVIRONMENT"),
+        matches.is_present("NULL_EOL"),
+        cmd,
+        unset_keys,
     ) {
         Ok(_) => (),
         Err(e) => {
@@ -34,102 +43,54 @@ fn main() {
     };
 }
 
-/// Print given `strings` to standard output.
-/// If `scape` true, it also prints the scape codes inside `strings`.
-/// If `no_newline` true, it does not print a newline after.
-fn echo(strings: Vec<String>, escape: bool, no_newline: bool) -> io::Result<()> {
-    let stdout = io::stdout();
-    let mut output = stdout.lock();
-
-    for (i, string) in strings.iter().enumerate() {
-        if i > 0 {
-            write!(output, " ")?;
-        }
-        if escape {
-            let should_stop = print_escape(string, &mut output)?;
-            if should_stop {
-                break;
-            }
-        } else {
-            write!(output, "{}", string)?;
+// run `man env`
+fn env(
+    kv: HashMap<String, String>,
+    ignore_environemnt: bool,
+    null_eol: bool,
+    mut cmd: Vec<String>,
+    unset_keys: Vec<String>,
+) -> io::Result<()> {
+    // Prints each argument on a separate line
+    let mut env_vars = HashMap::new();
+    for (key, value) in env::vars() {
+        if !unset_keys.contains(&key) {
+            env_vars.insert(key, value);
         }
     }
 
-    if !no_newline {
-        writeln!(output)?;
+    if ignore_environemnt {
+        env_vars = HashMap::new();
+    }
+
+    for (key, value) in kv {
+        env_vars.insert(key, value);
+    }
+
+    if cmd.len() > 0 {
+        println!("Spawning program");
+        let cmd_name = cmd.remove(0);
+        println!("{} ", cmd_name);
+        Command::new(cmd_name.clone())
+            .env_clear()
+            .args(cmd)
+            .envs(&env_vars)
+            .status()
+            .expect(&format!("{} failed to start.", cmd_name));
+        println!("done spawining..");
+    } else {
+        for (key, value) in env_vars.iter() {
+            print!("{}={}", key, value);
+            if !null_eol {
+                print!("\n");
+            }
+        }
+
+        if !null_eol {
+            // Let's be polite, and let the shell prompt start on a new line
+            println!("")
+        }
     }
 
     Ok(())
-}
-
-/// Parse a `input` code from `base` code to a UTF-8 char.
-/// The `max_digits` limits how many digits the `input` code can have.
-fn parse_code(
-    input: &mut Peekable<Chars>,
-    base: u32,
-    max_digits: u32,
-    bits_per_digit: u32,
-) -> Option<char> {
-    use std::char::from_u32;
-
-    let mut ret = 0x8000_0000;
-    for _ in 0..max_digits {
-        match input.peek().and_then(|c| c.to_digit(base)) {
-            Some(n) => ret = (ret << bits_per_digit) | n,
-            None => break,
-        }
-        input.next();
-    }
-    from_u32(ret)
-}
-
-/// Print the scape codes from `string`.
-/// `output` is where it is going to be printed.
-fn print_escape(string: &str, mut output: impl Write) -> io::Result<bool> {
-    let mut stop = false;
-    let mut buff = ['\\'; 2];
-    let mut iter = string.chars().peekable();
-    while let Some(mut c) = iter.next() {
-        let mut start_at = 1;
-
-        if c == '\\' {
-            if let Some(n) = iter.next() {
-                c = match n {
-                    '\\' => '\\',
-                    'a' => '\x07',
-                    'b' => '\x08',
-                    'c' => {
-                        stop = true;
-                        break;
-                    }
-                    'e' => '\x1b',
-                    'f' => '\x0c',
-                    'n' => '\n',
-                    'r' => '\r',
-                    't' => '\t',
-                    'v' => '\x0b',
-                    'x' => parse_code(&mut iter, 16, 2, 4).unwrap_or_else(|| {
-                        start_at = 0;
-                        n
-                    }),
-                    '0' => parse_code(&mut iter, 8, 3, 3).unwrap_or_else(|| {
-                        start_at = 0;
-                        n
-                    }),
-                    _ => {
-                        start_at = 0;
-                        n
-                    }
-                }
-            }
-        }
-
-        buff[1] = c;
-
-        for ch in &buff[start_at..] {
-            write!(output, "{}", ch)?;
-        }
-    }
-
-    Ok(stop)
 }

--- a/env/src/main.rs
+++ b/env/src/main.rs
@@ -1,0 +1,135 @@
+use std::{
+    io::{self, Write},
+    iter::Peekable,
+    process,
+    str::Chars,
+};
+
+use clap::{load_yaml, App};
+
+fn main() {
+    let yaml = load_yaml!("env.yml");
+    let matches = App::from_yaml(yaml).get_matches();
+
+    let strings: Vec<String> = {
+        // Safe to unwrap since we said it is required on clap yaml
+        let values = matches.values_of("STRING").unwrap();
+        let mut v = Vec::new();
+        for value in values {
+            v.push(value.to_owned());
+        }
+        v
+    };
+
+    match echo(
+        strings,
+        matches.is_present("escape"),
+        matches.is_present("no_newline"),
+    ) {
+        Ok(_) => (),
+        Err(e) => {
+            eprintln!("echo: Failed to write to stdout.\n{}", e);
+            process::exit(1);
+        }
+    };
+}
+
+/// Print given `strings` to standard output.
+/// If `scape` true, it also prints the scape codes inside `strings`.
+/// If `no_newline` true, it does not print a newline after.
+fn echo(strings: Vec<String>, escape: bool, no_newline: bool) -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut output = stdout.lock();
+
+    for (i, string) in strings.iter().enumerate() {
+        if i > 0 {
+            write!(output, " ")?;
+        }
+        if escape {
+            let should_stop = print_escape(string, &mut output)?;
+            if should_stop {
+                break;
+            }
+        } else {
+            write!(output, "{}", string)?;
+        }
+    }
+
+    if !no_newline {
+        writeln!(output)?;
+    }
+
+    Ok(())
+}
+
+/// Parse a `input` code from `base` code to a UTF-8 char.
+/// The `max_digits` limits how many digits the `input` code can have.
+fn parse_code(
+    input: &mut Peekable<Chars>,
+    base: u32,
+    max_digits: u32,
+    bits_per_digit: u32,
+) -> Option<char> {
+    use std::char::from_u32;
+
+    let mut ret = 0x8000_0000;
+    for _ in 0..max_digits {
+        match input.peek().and_then(|c| c.to_digit(base)) {
+            Some(n) => ret = (ret << bits_per_digit) | n,
+            None => break,
+        }
+        input.next();
+    }
+    from_u32(ret)
+}
+
+/// Print the scape codes from `string`.
+/// `output` is where it is going to be printed.
+fn print_escape(string: &str, mut output: impl Write) -> io::Result<bool> {
+    let mut stop = false;
+    let mut buff = ['\\'; 2];
+    let mut iter = string.chars().peekable();
+    while let Some(mut c) = iter.next() {
+        let mut start_at = 1;
+
+        if c == '\\' {
+            if let Some(n) = iter.next() {
+                c = match n {
+                    '\\' => '\\',
+                    'a' => '\x07',
+                    'b' => '\x08',
+                    'c' => {
+                        stop = true;
+                        break;
+                    }
+                    'e' => '\x1b',
+                    'f' => '\x0c',
+                    'n' => '\n',
+                    'r' => '\r',
+                    't' => '\t',
+                    'v' => '\x0b',
+                    'x' => parse_code(&mut iter, 16, 2, 4).unwrap_or_else(|| {
+                        start_at = 0;
+                        n
+                    }),
+                    '0' => parse_code(&mut iter, 8, 3, 3).unwrap_or_else(|| {
+                        start_at = 0;
+                        n
+                    }),
+                    _ => {
+                        start_at = 0;
+                        n
+                    }
+                }
+            }
+        }
+
+        buff[1] = c;
+
+        for ch in &buff[start_at..] {
+            write!(output, "{}", ch)?;
+        }
+    }
+
+    Ok(stop)
+}


### PR DESCRIPTION
Should fix #24 
There should be feature parity between `env` and this implementation :+1: sorry for the formatting, I had some problems with the rustfmt (it's complaining about syntax error, like edition is supposed to be a string instead of int etc).