### PR TITLE
rm: replaced bitwise or with logic or

### DIFF
--- a/rm/src/main.rs
+++ b/rm/src/main.rs
@@ -24,7 +24,7 @@ impl Flags {
             interactive: matches.is_present("interactive"),
             interactive_batch: matches.is_present("interactiveBatch"),
             preserve_root: !matches.is_present("noPreserveRoot"),
-            recursive: matches.is_present("recursive") | matches.is_present("recursive_compat"),
+            recursive: matches.is_present("recursive") || matches.is_present("recursive_compat"),
             dirs: matches.is_present("directories"),
             verbose: matches.is_present("verbose"),
         };


### PR DESCRIPTION
Found bug in `rm`. Was using `|` instead of `||` for boolean comparison. Not *technically* a bug but definitely not in line with best practices.