### PR TITLE
Unlink: Initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rmdir",
     "sleep",
     "true",
+    "unlink",
     "whoami",
     "uname",
     "users",

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ cargo build --manifest-path Haiku.toml
 |   uname  |             |         |   X  |
 | unexpand |      X      |         |      |
 |   uniq   |      X      |         |      |
-|  unlink  |      X      |         |      |
+|  unlink  |             |         |   X  |
 |  uptime  |      X      |         |      |
 |   users  |      X      |         |      |
 |    wc    |             |         |   X  |

--- a/unlink/Cargo.toml
+++ b/unlink/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "unlink"
+version = "0.0.0"
+authors = ["Torbjörn Lönnemark <tobbez@ryara.net>"]
+build = "build.rs"
+edition = "2018"
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["yaml", "wrap_help"] }
+
+[build-dependencies]
+clap = { version = "^2.33.0", features = ["yaml"] }

--- a/unlink/build.rs
+++ b/unlink/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+use clap::{load_yaml, App, Shell};
+
+fn main() {
+    let yaml = load_yaml!("src/unlink.yml");
+    let mut app = App::from_yaml(yaml);
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        _ => return,
+    };
+
+    app.gen_completions("unlink", Shell::Zsh, out_dir.clone());
+    app.gen_completions("unlink", Shell::Fish, out_dir.clone());
+    app.gen_completions("unlink", Shell::Bash, out_dir.clone());
+    app.gen_completions("unlink", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("unlink", Shell::Elvish, out_dir);
+}

--- a/unlink/src/main.rs
+++ b/unlink/src/main.rs
@@ -1,0 +1,17 @@
+use std::{fs, process};
+
+use clap::{load_yaml, App};
+
+fn main() {
+    let yaml = load_yaml!("unlink.yml");
+    let matches = App::from_yaml(yaml).get_matches();
+
+    let path = matches.value_of("FILE").unwrap();
+
+    // Note: std::fs::remove_file corresponds to unlink(2) at time of this writing, but that
+    // may change in the future according to the documentation.
+    if let Err(err) = fs::remove_file(path) {
+        eprintln!("unlink: cannot unlink '{}': {}", path, err);
+        process::exit(1);
+    }
+}

--- a/unlink/src/unlink.yml
+++ b/unlink/src/unlink.yml
@@ -1,0 +1,8 @@
+name: unlink
+version: "0.0.0"
+author: "Torbjörn Lönnemark <tobbez@ryara.net>"
+about: Call the unlink function to remove a specified file
+args:
+    - FILE:
+        help: "File to be unlinked"
+        required: true


### PR DESCRIPTION
Uses `libc::unlink` since documentation for the unlink implementations I checked are clear that it uses the unlink system call, and according to the rust documentation for `std::fs::remove_file`:

> This function currently corresponds to the unlink function on Unix and [...]. Note that, this may change in the future.