### PR TITLE
Cut: initial implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [workspace]
 members = [
-    "coreutils_core",
     "basename",
     "clear",
+    "coreutils_core",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/DragonflyBSD.toml
+++ b/DragonflyBSD.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/FreeBSD.toml
+++ b/FreeBSD.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/Fuchsia.toml
+++ b/Fuchsia.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/Haiku.toml
+++ b/Haiku.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/Linux.toml
+++ b/Linux.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/MacOS.toml
+++ b/MacOS.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/NetBSD.toml
+++ b/NetBSD.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/OpenBSD.toml
+++ b/OpenBSD.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/Solaris.toml
+++ b/Solaris.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/Unix.toml
+++ b/Unix.toml
@@ -3,6 +3,7 @@ members = [
     "coreutils_core",
     "basename",
     "clear",
+    "cut",
     "date",
     "dirname",
     "echo",

--- a/cut/Cargo.toml
+++ b/cut/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cut"
+version = "0.1.0"
+authors = ["Mats Kindahl <mats.kindahl@gmail.com>"]
+build = "build.rs"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["yaml", "wrap_help"] }
+
+[build-dependencies]
+clap = { version = "^2.33.0", features = ["yaml"] }

--- a/cut/build.rs
+++ b/cut/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+use clap::{load_yaml, App, Shell};
+
+fn main() {
+    let yaml = load_yaml!("src/cut.yml");
+    let mut app = App::from_yaml(yaml);
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        _ => return,
+    };
+
+    app.gen_completions("cut", Shell::Zsh, out_dir.clone());
+    app.gen_completions("cut", Shell::Fish, out_dir.clone());
+    app.gen_completions("cut", Shell::Bash, out_dir.clone());
+    app.gen_completions("cut", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("cut", Shell::Elvish, out_dir);
+}

--- a/cut/src/cut.yml
+++ b/cut/src/cut.yml
@@ -1,0 +1,67 @@
+name: cut
+version: "0.0.0"
+author: Mats Kindahl <mats.kindahl@gmail.com>
+about: >
+  Display selected parts of lines from each FILE to standard output.
+
+  With no FILE, or when FILE is -, read standard input.
+args:
+    - FILE:
+        help: File(s) to read, or '-' to read from stdin
+        required: false
+        multiple: true
+    - bytes:
+        long: bytes
+        short: b
+        value_name: LIST
+        help: Select only these bytes
+        conflicts_with:
+          - chars
+          - fields
+    - chars:
+        long: characters
+        short: c
+        value_name: LIST
+        conflicts_with:
+          - bytes
+          - fields
+        help: Select only these characters.
+    - input-delimiter:
+        long: delimiter
+        short: d
+        requires:
+          - fields
+        value_name: DELIM
+        help: Use DELIM instead of TAB for field delimiter.
+    - fields:
+        long: fields
+        short: f
+        conflicts_with:
+          - bytes
+          - chars
+        value_name: LIST
+        help: >
+          Select only these fields. Will display any line that contains
+          no delimiter character, unless the -s option is specified.
+    - complement:
+        long: complement
+        short: C
+        help: >
+          Complement the set of selected bytes, characters, or fields.
+    - only-delimited:
+        long: only-delimited
+        short: s
+        requires:
+          - fields
+        help: Do not display lines not containing delimiters
+    - output-delimiter:
+        long: output-delimiter
+        short: D
+        value_name: STRING
+        help: >
+          Use STRING as the output delimiter. Defaults to use the
+          input delimiter.
+    - zero-terminated:
+        long: zero-terminated
+        short: z
+        help: Line delimiter is NUL. Default is to use newline.

--- a/cut/src/main.rs
+++ b/cut/src/main.rs
@@ -1,0 +1,350 @@
+use clap::{load_yaml, App, ArgMatches};
+use std::{
+    cmp::min,
+    fmt,
+    fs::File,
+    io::{self, BufRead, BufReader},
+    num::ParseIntError,
+    result,
+};
+
+fn main() {
+    let yaml = load_yaml!("cut.yml");
+    let matches = App::from_yaml(yaml).get_matches();
+    let filenames: Vec<_> = match matches.values_of("FILE") {
+        Some(files) => files.collect(),
+        None => vec!["-"],
+    };
+
+    let result = make_cutter(&matches).and_then(|cutter| {
+        filenames.iter().map(|filename| cutter.process_file(&filename)).collect::<Result<Vec<_>>>()
+    });
+
+    if let Err(err) = result {
+        eprintln!("cut: {}", err);
+    }
+}
+
+#[derive(PartialEq, Debug)]
+enum Error {
+    SyntaxError(String),
+    RangeError(String),
+    ParseError(String),
+    IOError(String),
+    InternalError(String),
+}
+
+impl From<ParseIntError> for Error {
+    fn from(_err: ParseIntError) -> Error { Error::ParseError(format!("not an integer")) }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error { Error::IOError(format!("{}", err)) }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::SyntaxError(ref msg) => write!(f, "syntax error: {}", msg),
+            Error::RangeError(ref msg) => write!(f, "range error: {}", msg),
+            Error::ParseError(ref msg) => write!(f, "parse error: {}", msg),
+            Error::IOError(ref msg) => write!(f, "I/O error: {}", msg),
+            Error::InternalError(ref msg) => write!(f, "internal error: {}", msg),
+        }
+    }
+}
+
+type Result<T> = result::Result<T, Error>;
+
+/// Range of the form [start, one-after-end).
+#[derive(Debug, PartialEq, Clone, Copy)]
+struct Range(usize, usize);
+
+impl Range {
+    /// Parse a range into optional beginning and optional end.
+    ///
+    /// Accepted formats are:
+    /// - <number>
+    /// - "-" <number>
+    /// - <number> "-"
+    /// - <number> "-" <number>
+    /// # Errors
+    fn from_string(string: &str) -> Result<Range> {
+        let v: Vec<&str> = string.split('-').collect();
+        if string.len() == 0 || v.len() < 1 || v.len() > 2 {
+            return Err(Error::SyntaxError(format!("invalid byte or character range")));
+        }
+
+        // An interval with no endpoints at all should give an error.
+        if v.len() == 2 && v[0].len() == 0 && v[1].len() == 0 {
+            return Err(Error::RangeError(format!("invalid range with no endpoint")));
+        }
+
+        let lower = if v[0].len() == 0 { std::usize::MIN } else { v[0].parse::<usize>()? - 1 };
+        let upper = if v.len() == 1 {
+            lower + 1
+        } else if v[1].len() == 0 {
+            std::usize::MAX
+        } else {
+            v[1].parse::<usize>()?
+        };
+
+        if lower >= upper {
+            return Err(Error::RangeError(format!(
+                "invalid range {} ({} >= {})",
+                string,
+                lower + 1,
+                upper
+            )));
+        }
+
+        Ok(Range(lower, upper))
+    }
+}
+
+/// A set of ranges.
+#[derive(PartialEq, Debug)]
+struct RangeSet {
+    pub points: Vec<Range>,
+}
+
+impl RangeSet {
+    fn from_string(string: &str) -> Result<RangeSet> {
+        // Split the string at commas and parse the pieces as ranges.
+        let mut ranges =
+            string.split(',').map(|rng| Range::from_string(rng)).collect::<Result<Vec<Range>>>()?;
+
+        // Sort the ranges on the start of the range. This will place
+        // all ranges in correct order in the vector for the merging
+        // below.
+        ranges.sort_unstable_by_key(|rng| rng.0);
+
+        // Iterate over the ranges and merge ranges if there are
+        // any overlaps.
+        let mut current: Option<Range> = None;
+        let mut points = Vec::new();
+        for range in &ranges {
+            if let Some(rng) = current {
+                if range.0 <= rng.1 {
+                    current = Some(Range(rng.0, range.1));
+                } else {
+                    points.push(rng);
+                    current = Some(*range);
+                }
+            } else {
+                current = Some(*range);
+            }
+        }
+
+        if let Some(rng) = current {
+            points.push(rng);
+        }
+        Ok(RangeSet { points })
+    }
+}
+
+// Trait that is used to implement line cutting traits.
+trait Cutter {
+    fn process_line(&self, line: &str);
+
+    // Process an entire file. The special file name "-" will be
+    // reading from standard input.
+    fn process_file(&self, filename: &str) -> Result<()> {
+        let mut reader: Box<dyn io::Read> =
+            if filename == "-" { Box::new(io::stdin()) } else { Box::new(File::open(filename)?) };
+        self.process_input(&mut reader)
+    }
+
+    // Process input from an already opened reader.
+    fn process_input(&self, reader: &mut Box<dyn io::Read>) -> Result<()> {
+        let reader = BufReader::new(reader);
+        for line in reader.lines() {
+            match line {
+                Ok(ref line) => self.process_line(line),
+                Err(err) => return Err(Error::IOError(format!("I/O error: {}", err))),
+            }
+        }
+        Ok(())
+    }
+}
+
+// A byte cutter that will cut out bytes by position in the line.
+struct Bytes {
+    range_set: RangeSet,
+}
+
+impl Bytes {
+    fn new(range_set: RangeSet, _matches: &ArgMatches) -> Result<Bytes> { Ok(Bytes { range_set }) }
+}
+
+impl Cutter for Bytes {
+    fn process_line(&self, line: &str) {
+        // If line is shorter than range give, only print the parts of
+        // the line that are in range.
+        for range in &self.range_set.points {
+            if line.len() > range.0 {
+                print!("{}", &line[range.0..min(line.len(), range.1)]);
+            }
+        }
+        print!("\n");
+    }
+}
+
+// A character cutter that will cut out character by position in the
+// line.
+struct Chars {
+    range_set: RangeSet,
+}
+
+impl Chars {
+    fn new(range_set: RangeSet, _matches: &ArgMatches) -> Result<Chars> { Ok(Chars { range_set }) }
+}
+
+impl Cutter for Chars {
+    fn process_line(&self, line: &str) {
+        let pieces: Vec<&str> = self
+            .range_set
+            .points
+            .iter()
+            .map(|range| {
+                // If line is shorter than range give, only print the
+                // parts of the line that are in range.
+                if line.len() > range.0 { &line[range.0..min(line.len(), range.1)] } else { "" }
+            })
+            .collect();
+        println!("{}", pieces.join(""));
+    }
+}
+
+// A field cutter that will cut out delimited fields of the line.
+struct Fields {
+    range_set: RangeSet,
+    only_delimited: bool,
+    input_delimiter: String,
+    output_delimiter: String,
+}
+
+impl Fields {
+    fn new(range_set: RangeSet, matches: &ArgMatches) -> Result<Fields> {
+        let idelim = matches.value_of("input-delimiter").unwrap_or("\t");
+        if idelim.len() != 1 {
+            return Err(Error::SyntaxError(format!("single character for delimiter")));
+        }
+
+        let odelim = matches.value_of("output-delimiter").unwrap_or(idelim);
+        if odelim.len() != 1 {
+            return Err(Error::SyntaxError(format!("single character for delimiter")));
+        }
+
+        Ok(Fields {
+            range_set,
+            only_delimited: matches.is_present("only-delimited"),
+            input_delimiter: idelim.to_string(),
+            output_delimiter: odelim.to_string(),
+        })
+    }
+}
+
+impl Cutter for Fields {
+    fn process_line(&self, line: &str) {
+        let fields: Vec<&str> = line.split(&self.input_delimiter).collect();
+        if !self.only_delimited || fields.len() > 1 {
+            let pieces: Vec<_> = self
+                .range_set
+                .points
+                .iter()
+                .map(|range| {
+                    // If there are fewer fields than what the range
+                    // denotes, we print those fields that are in the
+                    // range.
+                    if fields.len() > range.0 {
+                        fields[range.0..min(fields.len(), range.1)].join(&self.output_delimiter)
+                    } else {
+                        "".to_string()
+                    }
+                })
+                .collect();
+            println!("{}", pieces.join(&self.output_delimiter));
+        }
+    }
+}
+
+// Factory function to create a cutter from command-line arguments.
+fn make_cutter(matches: &ArgMatches) -> Result<Box<dyn Cutter>> {
+    let line_delimiter = if matches.is_present("zero-terminated") { '\0' } else { '\n' };
+    if let Some(rng) = matches.value_of("bytes") {
+        let range_set = RangeSet::from_string(rng)?;
+        let cutter = Bytes::new(range_set, matches)?;
+        Ok(Box::new(cutter))
+    } else if let Some(rng) = matches.value_of("chars") {
+        let range_set = RangeSet::from_string(rng)?;
+        let cutter = Chars::new(range_set, matches)?;
+        Ok(Box::new(cutter))
+    } else if let Some(rng) = matches.value_of("fields") {
+        let range_set = RangeSet::from_string(rng)?;
+        let cutter = Fields::new(range_set, matches)?;
+        Ok(Box::new(cutter))
+    } else {
+        Err(Error::InternalError(format!("not possible to select cutter")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::usize::{MAX, MIN};
+
+    // Macro to assert that an expression matches a pattern.
+    macro_rules! assert_matches {
+        ($xpr:expr, $pat:pat) => {
+            match $xpr {
+                $pat => true,
+                ref xpr => {
+                    panic!("assert_matches: '{:?}' doesn't match '{}'", xpr, stringify!($pat))
+                },
+            }
+        };
+    }
+
+    #[test]
+    fn range_from_string() {
+        assert_eq!(Range::from_string("2"), Ok(Range(1, 2)));
+        assert_eq!(Range::from_string("-2"), Ok(Range(MIN, 2)));
+        assert_eq!(Range::from_string("2-"), Ok(Range(1, MAX)));
+        assert_eq!(Range::from_string("2-5"), Ok(Range(1, 5)));
+
+        assert_matches!(Range::from_string(""), Err(Error::SyntaxError(_)));
+        assert_matches!(Range::from_string("5-2"), Err(Error::RangeError(_)));
+        assert_matches!(Range::from_string("foo"), Err(Error::ParseError(_)));
+        assert_matches!(Range::from_string("2-0x12"), Err(Error::ParseError(_)));
+        assert_matches!(Range::from_string("-"), Err(Error::RangeError(_)));
+    }
+
+    #[test]
+    fn rangeset_from_string() {
+        assert_eq!(RangeSet::from_string("2"), Ok(RangeSet { points: vec![Range(1, 2)] }));
+        assert_eq!(RangeSet::from_string("-2"), Ok(RangeSet { points: vec![Range(MIN, 2)] }));
+        assert_eq!(RangeSet::from_string("2,3"), Ok(RangeSet { points: vec![Range(1, 3)] }));
+        assert_eq!(RangeSet::from_string("2-3"), Ok(RangeSet { points: vec![Range(1, 3)] }));
+        assert_eq!(
+            RangeSet::from_string("2-3,3-5,4-6"),
+            Ok(RangeSet { points: vec![Range(1, 6)] })
+        );
+        assert_eq!(
+            RangeSet::from_string("4-6,3-5,2-3"),
+            Ok(RangeSet { points: vec![Range(1, 6)] })
+        );
+        assert_eq!(
+            RangeSet::from_string("2,5-10"),
+            Ok(RangeSet { points: vec![Range(1, 2), Range(4, 10)] })
+        );
+        assert_eq!(
+            RangeSet::from_string("2,5-"),
+            Ok(RangeSet { points: vec![Range(1, 2), Range(4, MAX)] })
+        );
+        assert_eq!(
+            RangeSet::from_string("-2,5-"),
+            Ok(RangeSet { points: vec![Range(MIN, 2), Range(4, MAX)] })
+        );
+    }
+}


### PR DESCRIPTION
Implementation of Linux cut(1) with some differences:

* Linux cut(1) does not have a short option name for `--output-delimiter` so I picked `-D` (since short option for `--input-delimiter` is `-d`.

* Error messages are in some cases different.