### PR TITLE
Fix typos in utility names in yamls

### DIFF
--- a/env/src/env.yml
+++ b/env/src/env.yml
@@ -1,4 +1,4 @@
-name: echo
+name: env
 version: "0.0.0"
 author: Federico Ponzi <federico.ponzi92@gmail.com> and Eric Shimizu Karbstein <gr41.j4ck@gmail.com>
 about: "Set environment and execute command, or print environment\n\n\

--- a/nohup/src/nohup.yml
+++ b/nohup/src/nohup.yml
@@ -1,4 +1,4 @@
-name: yes
+name: nohup
 version: "0.0.1"
 author: Federico Ponzi <federico.ponzi@gmail.com>
 about: "Run a commmand and ignore SIGHUP signals. If standard input is a terminal, redirect it from an unreadable file.

--- a/wc/src/wc.yml
+++ b/wc/src/wc.yml
@@ -1,4 +1,4 @@
-name: echo
+name: wc
 version: "0.0.0"
 author: Giacomo Parolini <silverweed1991@gmail.com>
 about: "Display newline, word and byte counts for each FILE, and a total line if more than one FILE is specified. A word is a non-zero-length sequence of characters delimited by white space.\n\nWith no FILE, or when FILE is -, read standard input."


### PR DESCRIPTION
Hi.

This fixes trails of copy&pastes of yaml files showing incorrect utility name in help message.