### PR TITLE
Cat: Implement with support for -snbE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "basename",
+    "cat",
     "chroot",
     "clear",
     "coreutils_core",

--- a/DragonflyBSD.toml
+++ b/DragonflyBSD.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/FreeBSD.toml
+++ b/FreeBSD.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/Fuchsia.toml
+++ b/Fuchsia.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "clear",
     "cut",
     "date",

--- a/Haiku.toml
+++ b/Haiku.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/Linux.toml
+++ b/Linux.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/MacOS.toml
+++ b/MacOS.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/NetBSD.toml
+++ b/NetBSD.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/OpenBSD.toml
+++ b/OpenBSD.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/Solaris.toml
+++ b/Solaris.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/Unix.toml
+++ b/Unix.toml
@@ -2,6 +2,7 @@
 members = [
     "coreutils_core",
     "basename",
+    "cat",
     "chroot",
     "clear",
     "cut",

--- a/cat/Cargo.toml
+++ b/cat/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "cat"
+version = "0.1.0"
+authors = ["Anubhab Ghosh <anubhabghosh.me@gmail.com>"]
+build = "build.rs"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["yaml", "wrap_help"] }
+
+[build-dependencies]
+clap = { version = "^2.33.0", features = ["yaml"] }

--- a/cat/build.rs
+++ b/cat/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+
+use clap::{load_yaml, App, Shell};
+
+fn main() {
+    let yaml = load_yaml!("src/cat.yml");
+    let mut app = App::from_yaml(yaml);
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        _ => return,
+    };
+
+    app.gen_completions("cat", Shell::Zsh, out_dir.clone());
+    app.gen_completions("cat", Shell::Fish, out_dir.clone());
+    app.gen_completions("cat", Shell::Bash, out_dir.clone());
+    app.gen_completions("cat", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("cat", Shell::Elvish, out_dir);
+}

--- a/cat/src/cat.yml
+++ b/cat/src/cat.yml
@@ -1,0 +1,25 @@
+name: cat
+version: "0.0.0"
+author: Anubhab Ghosh <anubhabghosh.me@gmail.com>
+about: "Concatenate and display files"
+args:
+    - number:
+        help: Number all output lines
+        long: number
+        short: n
+    - numberNonblank:
+        help: Number nonempty output lines, overrides -n
+        long: number-nonblank
+        short: b
+    - showEnds:
+        help: Display $ at end of each line
+        long: show-ends
+        short: E
+    - squeezeBlank:
+        help: Squeeze multiple adjacent empty lines, causing the output to be single spaced
+        long: squeeze-blank
+        short: s
+    - FILE:
+        help: "The file operands are processed in command-line order"
+        long_help: "The file operands are processed in command-line order. If file is a single dash (‘-’) or absent, cat reads from the standard input."
+        multiple: true

--- a/cat/src/main.rs
+++ b/cat/src/main.rs
@@ -1,0 +1,149 @@
+use std::{
+    fs::File,
+    io::{prelude::*, stdin, BufReader, ErrorKind},
+};
+
+use clap::{load_yaml, App, AppSettings::ColoredHelp, ArgMatches};
+
+fn main() {
+    let yaml = load_yaml!("cat.yml");
+    let matches = App::from_yaml(yaml).settings(&[ColoredHelp]).get_matches();
+
+    let flags = CatFlags::from_matches(&matches);
+
+    let files: Vec<String> = match matches.values_of("FILE") {
+        Some(m) => m.map(String::from).collect(),
+        None => vec![String::from("-")],
+    };
+
+    let mut exit_code = 0;
+
+    let mut line_number = 1;
+    let mut last_line_empty = false;
+    for filename in files.iter() {
+        if filename == "-" {
+            loop {
+                let mut line = String::new();
+
+                match stdin().read_line(&mut line) {
+                    Ok(0) => break, // EOF
+                    Ok(_) => {
+                        line.pop();
+                        print_line(line, flags, &mut line_number, &mut last_line_empty)
+                    },
+                    Err(error) => eprintln!("cat: stdin: {}", error),
+                }
+            }
+        } else {
+            match File::open(filename) {
+                Ok(file) => {
+                    for line in BufReader::new(file).lines() {
+                        let line = match line {
+                            Ok(line) => line,
+                            Err(error) => {
+                                eprintln!("cat: {}: I/O error: {}", filename, error);
+                                exit_code = 1;
+                                break;
+                            },
+                        };
+                        print_line(line, flags, &mut line_number, &mut last_line_empty);
+                    }
+                },
+                Err(e) => {
+                    exit_code = 1;
+                    match e.kind() {
+                        ErrorKind::NotFound => {
+                            eprintln!("cat: {}: No such file or directory", filename)
+                        },
+                        ErrorKind::PermissionDenied => {
+                            eprintln!("cat: {}: Permission denied", filename)
+                        },
+                        _ => eprintln!("cat: {}: Unknown error", filename),
+                    }
+                },
+            };
+        }
+    }
+
+    std::process::exit(exit_code);
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CatFlags {
+    pub number: bool,
+    pub number_nonblank: bool,
+    pub show_ends: bool,
+    pub squeeze_blank: bool,
+}
+
+impl CatFlags {
+    pub fn from_matches(matches: &ArgMatches) -> Self {
+        CatFlags {
+            number: matches.is_present("number"),
+            number_nonblank: matches.is_present("numberNonblank"),
+            show_ends: matches.is_present("showEnds"),
+            squeeze_blank: matches.is_present("squeezeBlank"),
+        }
+    }
+}
+
+fn print_line(line: String, flags: CatFlags, line_number: &mut usize, last_line_empty: &mut bool) {
+    if flags.squeeze_blank {
+        if line.is_empty() {
+            if !*last_line_empty {
+                if !flags.number_nonblank && flags.number {
+                    if flags.show_ends {
+                        println!("{:6}  $", line_number);
+                    } else {
+                        println!("{:6}  ", line_number);
+                    }
+
+                    *line_number += 1;
+                } else if flags.show_ends {
+                    println!("$");
+                } else {
+                    println!();
+                }
+            }
+            *last_line_empty = true;
+        } else {
+            if flags.number || flags.number_nonblank {
+                if flags.show_ends {
+                    println!("{:6}  {}$", line_number, line);
+                } else {
+                    println!("{:6}  {}", line_number, line);
+                }
+                *line_number += 1;
+            } else if flags.show_ends {
+                println!("{}$", line);
+            } else {
+                println!("{}", line);
+            }
+            *last_line_empty = false;
+        }
+    } else if flags.number_nonblank {
+        if !line.is_empty() {
+            if flags.show_ends {
+                println!("{:6}  {}$", line_number, line);
+            } else {
+                println!("{:6}  {}", line_number, line);
+            }
+            *line_number += 1;
+        } else if flags.show_ends {
+            println!("$");
+        } else {
+            println!();
+        }
+    } else if flags.number {
+        if flags.show_ends {
+            println!("{:6}  {}$", line_number, line);
+        } else {
+            println!("{:6}  {}", line_number, line);
+        }
+        *line_number += 1;
+    } else if flags.show_ends {
+        println!("{}$", line);
+    } else {
+        println!("{}", line);
+    }
+}


### PR DESCRIPTION
Add cat with support for argument snbE according to GNU man page. The BSD e argument is a combination of E and v in GNU, and E is a separate argument in GNU. evTt are not yet supported.