### PR TITLE
Fixing template clap call.

### DIFF
--- a/.template/src/main.rs
+++ b/.template/src/main.rs
@@ -1,5 +1,5 @@
 mod cli;
 
 fn main() {
-    let matches = cli::app().get_matches();
+    let matches = cli::create_app().get_matches();
 }


### PR DESCRIPTION
Replacing app with create_app.

All tools use:
`let matches = cli::create_app().get_matches();`

.template had:
`let matches = cli::app().get_matches();`

Which caused compilation errors.