### PR TITLE
Uniq: fixing short help option -h

### DIFF
--- a/uniq/src/cli.rs
+++ b/uniq/src/cli.rs
@@ -9,7 +9,6 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .about(crate_description!())
         .help_message("Display help information.")
         .version_message("Display version information.")
-        .help_short("?")
         .settings(&[ColoredHelp])
         .arg(
             Arg::with_name("INPUT")


### PR DESCRIPTION
Earlier incorrectly binded to -?
