### PR TITLE
Implement sort

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/DragonflyBSD.toml
+++ b/DragonflyBSD.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/FreeBSD.toml
+++ b/FreeBSD.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/Fuchsia.toml
+++ b/Fuchsia.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/Haiku.toml
+++ b/Haiku.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/Linux.toml
+++ b/Linux.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/MacOS.toml
+++ b/MacOS.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/NetBSD.toml
+++ b/NetBSD.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/OpenBSD.toml
+++ b/OpenBSD.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cargo install --path .
 |  rmdir   |             |         |   X   |
 |   sed    |      X      |         |       |
 |   seq    |             |    X    |       |
-|   sort   |      X      |         |       |
+|   sort   |             |    X    |       |
 |  sleep   |             |         |   X   |
 |  split   |      X      |         |       |
 |   stat   |      X      |         |       |

--- a/Solaris.toml
+++ b/Solaris.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/Unix.toml
+++ b/Unix.toml
@@ -37,6 +37,7 @@ members = [
     "rmdir",
     "seq",
     "sleep",
+    "sort",
     "touch",
     "true",
     "tty",

--- a/sort/Cargo.toml
+++ b/sort/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sort"
+version = "0.1.0"
+authors = ["Anubhab Ghosh <anubhabghosh.me@gmail.com>"]
+license = "MPL-2.0-no-copyleft-exception"
+build = "build.rs"
+edition = "2018"
+description = "Concatenate and display files."
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["wrap_help"] }
+
+[build-dependencies]
+clap = "^2.33.0"

--- a/sort/Cargo.toml
+++ b/sort/Cargo.toml
@@ -11,6 +11,11 @@ description = "Concatenate and display files."
 
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
+fail = "0.4.0"
 
 [build-dependencies]
 clap = "^2.33.0"
+
+[dev-dependencies]
+tempfile = "3.1.0"
+fail = "0.4.0"

--- a/sort/Cargo.toml
+++ b/sort/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Anubhab Ghosh <anubhabghosh.me@gmail.com>"]
 license = "MPL-2.0-no-copyleft-exception"
 build = "build.rs"
 edition = "2018"
-description = "Concatenate and display files."
+description = "Sort or merge all FILE(s)."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/sort/build.rs
+++ b/sort/build.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+use clap::Shell;
+
+#[path = "src/cli.rs"]
+mod cli;
+
+fn main() {
+    let mut app = cli::create_app();
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("No OUT_DIR: {}", err);
+            return;
+        },
+    };
+
+    app.gen_completions("sort", Shell::Zsh, out_dir.clone());
+    app.gen_completions("sort", Shell::Fish, out_dir.clone());
+    app.gen_completions("sort", Shell::Bash, out_dir.clone());
+    app.gen_completions("sort", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("sort", Shell::Elvish, out_dir);
+}

--- a/sort/build.rs
+++ b/sort/build.rs
@@ -13,7 +13,7 @@ fn main() {
         Err(err) => {
             eprintln!("No OUT_DIR: {}", err);
             return;
-        }
+        },
     };
 
     app.gen_completions("sort", Shell::Zsh, out_dir.clone());

--- a/sort/build.rs
+++ b/sort/build.rs
@@ -13,7 +13,7 @@ fn main() {
         Err(err) => {
             eprintln!("No OUT_DIR: {}", err);
             return;
-        },
+        }
     };
 
     app.gen_completions("sort", Shell::Zsh, out_dir.clone());

--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -19,14 +19,11 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                      single dash (‘-’) or absent, sort reads from the standard input.",
                 )
                 .multiple(true),
-            
         )
         .arg(
             Arg::with_name("merge_only")
                 .help("Merge only")
-                .long_help(
-                    "Merge only; the input file shall be assumed to be already sorted.",
-                )
+                .long_help("Merge only; the input file shall be assumed to be already sorted.")
                 .short("m"),
         )
         .arg(
@@ -34,7 +31,8 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Output file")
                 .value_name("FILE")
                 .long_help(
-                    "Specify the name of an output file to be used instead of the standard output. This file can be the same as one of the input files.",
+                    "Specify the name of an output file to be used instead of the standard \
+                     output. This file can be the same as one of the input files.",
                 )
                 .short("o"),
         )

--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -1,0 +1,24 @@
+use clap::{
+    crate_authors, crate_description, crate_name, crate_version, App, AppSettings::ColoredHelp, Arg,
+};
+
+pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
+    App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .help_message("Display help information.")
+        .version_message("Display version information.")
+        .help_short("?")
+        .settings(&[ColoredHelp])
+        .arg(
+            Arg::with_name("FILE")
+                .help("The file( operands are processed in command-line order.")
+                .long_help(
+                    "The file operands are processed in command-line order.\n\nIf file is a \
+                     single dash (‘-’) or absent, cat reads from the standard input.",
+                )
+                .multiple(true),
+        )
+    // Add args here
+}

--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -13,26 +13,26 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .settings(&[ColoredHelp])
         .arg(
             Arg::with_name("FILE")
-                .help("The file( operands are processed in command-line order.")
+                .help("File(s) to be sorted, merged or checked.")
                 .long_help(
-                    "The file operands are processed in command-line order.\n\nIf file is a \
-                     single dash (‘-’) or absent, sort reads from the standard input.",
+                    "File(s) to be sorted, merged or checked.\n\nIf FILE is ‘-’ or absent, sort \
+                     reads from the standard input.",
                 )
                 .multiple(true),
         )
         .arg(
             Arg::with_name("merge_only")
-                .help("Merge only")
-                .long_help("Merge only; the input file shall be assumed to be already sorted.")
+                .help("Merge files.")
+                .long_help("Merge files\n\nThe input FILE(s) are assumed to be already sorted.")
                 .short("m"),
         )
         .arg(
             Arg::with_name("output")
-                .help("Output file")
                 .value_name("FILE")
+                .help("Write result to FILE instead of standard output.")
                 .long_help(
-                    "Specify the name of an output file to be used instead of the standard \
-                     output. This file can be the same as one of the input files.",
+                    "Write result to FILE instead of standard output.\n\nThis FILE can be the \
+                     same one as one of the input FILE(s)",
                 )
                 .short("o"),
         )

--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -16,9 +16,27 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .help("The file( operands are processed in command-line order.")
                 .long_help(
                     "The file operands are processed in command-line order.\n\nIf file is a \
-                     single dash (‘-’) or absent, cat reads from the standard input.",
+                     single dash (‘-’) or absent, sort reads from the standard input.",
                 )
                 .multiple(true),
+            
+        )
+        .arg(
+            Arg::with_name("merge_only")
+                .help("Merge only")
+                .long_help(
+                    "Merge only; the input file shall be assumed to be already sorted.",
+                )
+                .short("m"),
+        )
+        .arg(
+            Arg::with_name("output")
+                .help("Output file")
+                .value_name("FILE")
+                .long_help(
+                    "Specify the name of an output file to be used instead of the standard output. This file can be the same as one of the input files.",
+                )
+                .short("o"),
         )
     // Add args here
 }

--- a/sort/src/main.rs
+++ b/sort/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{prelude::*, stdin, BufReader, ErrorKind},
+    io::{prelude::*, stdin, BufReader},
 };
 
 use clap::ArgMatches;
@@ -10,39 +10,353 @@ mod cli;
 fn main() {
     let matches = cli::create_app().get_matches();
 
-    let flags = SortFlags::from_matches(&matches);
+    let result = main_sort(matches);
 
-    let filenames: Vec<String> = match matches.values_of("FILE") {
-        Some(m) => m.map(String::from).collect(),
-        None => unimplemented!("Implement input from stdin"),
+    let exit_code = match result {
+        Ok(_) => 0,
+        Err(err) => {
+            match writeln!(std::io::stderr(), "{:?}", err) {
+                Err(err) => println!("{:?}", err),
+                _ => {},
+            };
+            1
+        },
     };
-
-    let exit_code = 0;
-
-    let mut lines: Vec<String> = filenames
-        .into_iter()
-        .filter_map(|filename| File::open(filename).ok())
-        .flat_map(|file| BufReader::new(file).lines())
-        .filter_map(|l| l.ok())
-        .collect();
-    lines.sort();
-    for (line_number, line) in lines.into_iter().enumerate() {
-        print_line(line, flags, line_number);
-    }
-
     std::process::exit(exit_code);
 }
 
-#[derive(Debug, Clone, Copy)]
-struct SortFlags {
+fn main_sort(matches: clap::ArgMatches) -> Result<(), SortError> {
+    let mut flags = SortFlags::from_matches(&matches)?;
+    let inputs = get_inputs(&matches)?;
+
+    let lines = sort(&flags, Box::new(inputs.into_iter()))?;
+
+    for line in lines {
+        print_line(line, & mut flags)?;
+    }
+
+    Ok(())
 }
 
-impl SortFlags {
-    pub fn from_matches(matches: &ArgMatches) -> Self {
-        SortFlags {}
+fn get_inputs(matches: &clap::ArgMatches) -> Result<Vec<Box<dyn Read>>, SortError> {
+    use std::io::Error;
+
+    match matches.values_of("FILE") {
+        Some(m) => {
+            println!("{:?}", m);
+            let files: Vec<Result<File, Error>> = m
+                .map(|filename| File::open(filename))
+                .collect();
+            let files: Result<Vec<File>, Error> = files
+                .into_iter()
+                .map(|p| p)
+                .collect();
+            
+            match files {
+                Ok(files) => {
+                    let mut inputs: Vec<Box<dyn Read>> = vec![];
+                    for file in files {
+                        inputs.push(Box::new(file));
+                    }
+                    Ok(inputs)
+                },
+                Err(err) => Err(SortError::FileReadError(err)),
+            }
+        },
+        None => {
+            Ok(vec![
+                Box::new(stdin())
+            ])
+        }
     }
 }
 
-fn print_line(line: String, flags: SortFlags, line_number: usize) {
-    println!("{:6}  {}", line_number, line);
+fn sort(flags: &SortFlags, inputs: Box<dyn Iterator<Item=Box<dyn Read>>>) -> Result<impl Iterator<Item=String>, SortError> {
+    let lines: Result<Vec<String>, std::io::Error> = inputs
+        .map(|file| BufReader::new(file))
+        .flat_map(|reader| reader.lines())
+        .collect();
+    
+    let mut lines = lines.map_err(SortError::FileReadError)?;
+    if !flags.merge_only {
+        lines.sort();
+    }
+
+    Ok(lines.into_iter())
+}
+
+fn print_line(line: String, flags: & mut SortFlags) -> Result<(), SortError> {
+    writeln!(flags.output, "{}", line).map_err(|err| SortError::FileWriteError(err))
+}
+
+struct SortFlags {
+    merge_only: bool,
+    output: Box<dyn Write>,
+}
+
+impl SortFlags {
+    pub fn from_matches(matches: &ArgMatches) -> Result<Self, SortError> {
+        let merge_only = matches.is_present("merge_only");
+        let output: Box<dyn Write> = match matches.value_of("output") {
+            Some(path) => {
+                match File::create(path) {
+                    Ok(file) => Box::new(file),
+                    Err(err) => return Err(SortError::FileWriteError(err))
+                }
+            },
+            None => {
+                Box::new(std::io::stdout())
+            },
+        };
+        Ok(SortFlags {
+            merge_only,
+            output,
+        })
+    }
+}
+
+#[derive(Debug)]
+enum SortError {
+    FileReadError(std::io::Error),
+    FileWriteError(std::io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::{NamedTempFile};
+
+    macro_rules! create_temp_files {
+        () => {
+            {
+                let mut file1 = NamedTempFile::new().unwrap();
+                let mut file2 = NamedTempFile::new().unwrap();
+                let mut file3 = NamedTempFile::new().unwrap();
+                writeln!(file1, "file1").unwrap();
+                writeln!(file2, "file2").unwrap();
+                writeln!(file3, "file3").unwrap();
+
+                (file1, file2, file3)
+            }
+        };
+        ($content1: expr, $content2: expr, $content3: expr) => {
+            {
+                let mut file1 = NamedTempFile::new().unwrap();
+                let mut file2 = NamedTempFile::new().unwrap();
+                let mut file3 = NamedTempFile::new().unwrap();
+                writeln!(file1, $content1).unwrap();
+                writeln!(file2, $content2).unwrap();
+                writeln!(file3, $content3).unwrap();
+
+                (file1, file2, file3)
+            }
+        };
+    }
+
+    macro_rules! get_matches {
+        ($file1: ident, $file2: ident, $file3: ident) => {
+            cli::create_app()
+                .get_matches_from(vec![
+                    "sort",
+                    $file1.path().to_str().unwrap(),
+                    $file2.path().to_str().unwrap(),
+                    $file3.path().to_str().unwrap(),
+                ]);
+        };
+        ($file1: ident, $file2: ident, $file3: ident, $output_path: ident) => {
+            cli::create_app()
+                .get_matches_from(vec![
+                    "sort",
+                    "-o",
+                    $output_path.path().to_str().unwrap(),
+                    $file1.path().to_str().unwrap(),
+                    $file2.path().to_str().unwrap(),
+                    $file3.path().to_str().unwrap(),
+                ]);
+        };
+        ($filePathAsString: ident) => {
+            cli::create_app()
+                .get_matches_from(vec![
+                    "sort",
+                    $filePathAsString,
+                ]);
+        };
+    }
+
+    #[test]
+    fn test_get_inputs_with_values() {        
+        let (file1, file2, file3) = create_temp_files!();
+        let matches = get_matches!(file1, file2, file3);
+
+        let inputs = get_inputs(&matches).unwrap();
+
+        assert_eq!(3, inputs.len());
+
+        let expected: Vec<String> = vec![file1, file2, file3]
+            .iter()
+            .map(|f| std::fs::read_to_string(f).unwrap())
+            .collect();
+        assert_eq!(vec![
+            "file1\n",
+            "file2\n",
+            "file3\n",
+        ], expected);
+    }
+
+    #[test]
+    fn test_get_inputs_fails() {
+        let wrong_path = "/unexisting/path/I/hope";
+        let matches = get_matches!(wrong_path);
+
+        let error = get_inputs(&matches);
+
+        let error = match error {
+            Err(err) => err,
+            Ok(_) => panic!("Wrong!"),
+        };
+        let error = match error {
+            SortError::FileReadError(err) => err,
+            _ => panic!("Wrong!"),
+        };
+
+        assert_eq!(std::io::ErrorKind::NotFound, error.kind());
+    }
+
+    #[test]
+    fn test_get_inputs_no_value() {        
+        let matches = cli::create_app()
+            .get_matches_from(vec![
+                "sort",
+            ]);
+        let inputs = get_inputs(&matches).unwrap();
+
+        assert_eq!(1, inputs.len());
+    }
+
+    #[test]
+    fn test_sort() {        
+        let flags = SortFlags {
+            merge_only: false,
+            output: Box::new(std::io::stdout()),
+        };
+        let (file1, file2, file3) = create_temp_files!("file3", "file2", "file1");
+        let matches = get_matches!(file1, file2, file3);
+
+        let inputs = get_inputs(&matches).unwrap();
+
+        let res = sort(&flags, Box::new(inputs.into_iter())).unwrap();
+
+        let res: Vec<String> = res.collect();
+
+        assert_eq!(
+            vec![
+                "file1",
+                "file2",
+                "file3",
+            ],
+            res
+        )
+    }
+
+    #[test]
+    fn test_sort_multi_lines() {        
+        let flags = SortFlags {
+            merge_only: false,
+            output: Box::new(std::io::stdout()),
+        };
+        let (file1, file2, file3) = create_temp_files!(
+            "line1\nline3\nline4",
+            "line8\nline2\nline5",
+            "line6\nline7\nline9"
+        );
+        let matches = get_matches!(file1, file2, file3);
+
+        let inputs = get_inputs(&matches).unwrap();
+
+        let res = sort(&flags, Box::new(inputs.into_iter())).unwrap();
+
+        let res: Vec<String> = res.collect();
+
+        assert_eq!(
+            vec![
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+                "line5",
+                "line6",
+                "line7",
+                "line8",
+                "line9",
+            ],
+            res
+        )
+    }
+
+    #[test]
+    fn test_sort_different_file_length() {        
+        let flags = SortFlags {
+            merge_only: false,
+            output: Box::new(std::io::stdout()),
+        };
+        let (file1, file2, file3) = create_temp_files!(
+            "line1\nline3\nline4\nline8\nline2\nline5\nline6",
+            "line7",
+            "line9"
+        );
+        let matches = get_matches!(file1, file2, file3);
+
+        let inputs = get_inputs(&matches).unwrap();
+
+        let res = sort(&flags, Box::new(inputs.into_iter())).unwrap();
+
+        let res: Vec<String> = res.collect();
+
+        assert_eq!(
+            vec![
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+                "line5",
+                "line6",
+                "line7",
+                "line8",
+                "line9",
+            ],
+            res
+        )
+    }
+
+
+    #[test]
+    fn test_main_sort() {
+        let output_file = NamedTempFile::new().unwrap();
+        let output_file_path = output_file.path();
+
+        let (file1, file2, file3) = create_temp_files!(
+            "line1\nline3\nline4\nline8\nline2\nline5\nline6",
+            "line7",
+            "line9"
+        );
+        let matches = get_matches!(file1, file2, file3, output_file);
+
+        main_sort(matches).unwrap();
+
+        assert_eq!(
+            vec![
+                "line1",
+                "line2",
+                "line3",
+                "line4",
+                "line5",
+                "line6",
+                "line7",
+                "line8",
+                "line9",
+                ""
+            ].join("\n"),
+            std::fs::read_to_string(output_file_path).unwrap()
+        )
+    }
 }

--- a/sort/src/main.rs
+++ b/sort/src/main.rs
@@ -1,0 +1,48 @@
+use std::{
+    fs::File,
+    io::{prelude::*, stdin, BufReader, ErrorKind},
+};
+
+use clap::ArgMatches;
+
+mod cli;
+
+fn main() {
+    let matches = cli::create_app().get_matches();
+
+    let flags = SortFlags::from_matches(&matches);
+
+    let filenames: Vec<String> = match matches.values_of("FILE") {
+        Some(m) => m.map(String::from).collect(),
+        None => unimplemented!("Implement input from stdin"),
+    };
+
+    let exit_code = 0;
+
+    let mut lines: Vec<String> = filenames
+        .into_iter()
+        .filter_map(|filename| File::open(filename).ok())
+        .flat_map(|file| BufReader::new(file).lines())
+        .filter_map(|l| l.ok())
+        .collect();
+    lines.sort();
+    for (line_number, line) in lines.into_iter().enumerate() {
+        print_line(line, flags, line_number);
+    }
+
+    std::process::exit(exit_code);
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SortFlags {
+}
+
+impl SortFlags {
+    pub fn from_matches(matches: &ArgMatches) -> Self {
+        SortFlags {}
+    }
+}
+
+fn print_line(line: String, flags: SortFlags, line_number: usize) {
+    println!("{:6}  {}", line_number, line);
+}


### PR DESCRIPTION
In this PR there's the first implementation of `sort` command ( #46 )

We need to discuss about:
- what happen when a files doesn't exists: `sort` ignores it or fails?
- which flags should we implement? No one is implemented here.
- for the time being, the implementation is in memory and no temp file technique is implemented
- shall we support stdin as input?
- for test purpose, use `println!` macro is not a good choice: what we can use instead?