### PR TITLE
Sort: Adding long option --merge for -m flag, and some refactoring

### DIFF
--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -12,7 +12,8 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .help_short("?")
         .settings(&[ColoredHelp])
         .arg(
-            Arg::with_name("FILE")
+            Arg::with_name("INPUT_FILES")
+                .value_name("INPUT_FILES")
                 .help("File(s) to be sorted, merged or checked.")
                 .long_help(
                     "File(s) to be sorted, merged or checked.\n\nIf FILE is ‘-’ or absent, sort \
@@ -28,7 +29,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .long("merge"),
         )
         .arg(
-            Arg::with_name("output")
+            Arg::with_name("OUTPUT_FILE")
                 .value_name("FILE")
                 .help("Write result to FILE instead of standard output.")
                 .long_help(

--- a/sort/src/cli.rs
+++ b/sort/src/cli.rs
@@ -24,7 +24,8 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
             Arg::with_name("merge_only")
                 .help("Merge files.")
                 .long_help("Merge files\n\nThe input FILE(s) are assumed to be already sorted.")
-                .short("m"),
+                .short("m")
+                .long("merge"),
         )
         .arg(
             Arg::with_name("output")
@@ -32,7 +33,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .help("Write result to FILE instead of standard output.")
                 .long_help(
                     "Write result to FILE instead of standard output.\n\nThis FILE can be the \
-                     same one as one of the input FILE(s)",
+                     same one as one of the input FILE(s).",
                 )
                 .short("o"),
         )


### PR DESCRIPTION
Sort: `-m` long option `--merge` was missing, so I added it, and took the opportunity to make another commit refactoring some of the code, making it simpler.

I see that we rework the whole error treatment of `sort`, I'll probably be able to fix it soon, looks simple but will need a lot of restructuring to make it more suitable for the other flags to be implemented, cause in the way things are now, those flags won't fit in the program functions.