### PR TITLE
Implement tail

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/DragonflyBSD.toml
+++ b/DragonflyBSD.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/FreeBSD.toml
+++ b/FreeBSD.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/Fuchsia.toml
+++ b/Fuchsia.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/Haiku.toml
+++ b/Haiku.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/Linux.toml
+++ b/Linux.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/MacOS.toml
+++ b/MacOS.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/NetBSD.toml
+++ b/NetBSD.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/OpenBSD.toml
+++ b/OpenBSD.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cargo install --path .
 |  split   |      X      |         |       |
 |   stat   |      X      |         |       |
 |   stty   |      X      |         |       |
-|   tail   |      X      |         |       |
+|   tail   |             |    X    |       |
 |   tee    |      X      |         |       |
 |   test   |      X      |         |       |
 |   time   |      X      |         |       |

--- a/Solaris.toml
+++ b/Solaris.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/Unix.toml
+++ b/Unix.toml
@@ -39,6 +39,7 @@ members = [
     "seq",
     "sleep",
     "sort",
+    "tail",
     "touch",
     "true",
     "tty",

--- a/tail/Cargo.toml
+++ b/tail/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tail"
+version = "0.1.0"
+authors = ["Jeremy Jackson <git@jeremyvii.com>"]
+license = "MPL-2.0-no-copyleft-exception"
+build = "build.rs"
+edition = "2018"
+description = """
+This filter displays the last count lines or bytes of each specified FILE, or \
+of the standard input if no files are specified. If count is omitted it \
+defaults to 10.
+
+If more than a single file is specified, each file is preceded by a header \
+consisting of the string ``==> XXX <=='' where ``XXX'' is the name of the file.
+""" # Edit this
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["wrap_help"] }
+
+[build-dependencies]
+clap = "^2.33.0"

--- a/tail/Cargo.toml
+++ b/tail/Cargo.toml
@@ -7,12 +7,12 @@ build = "build.rs"
 edition = "2018"
 description = """
 This filter displays the last count lines or bytes of each specified FILE, or \
-of the standard input if no files are specified. If count is omitted it \
-defaults to 10.
+of the standard input if no files are specified or "-" is given as a \
+file name. If count is omitted it defaults to 10.
 
 If more than a single file is specified, each file is preceded by a header \
 consisting of the string ``==> XXX <=='' where ``XXX'' is the name of the file.
-""" # Edit this
+"""
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/tail/build.rs
+++ b/tail/build.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+use clap::Shell;
+
+#[path = "src/cli.rs"]
+mod cli;
+
+fn main() {
+    let mut app = cli::create_app();
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("No OUT_DIR: {}", err);
+            return;
+        },
+    };
+
+    app.gen_completions("template", Shell::Zsh, out_dir.clone());
+    app.gen_completions("template", Shell::Fish, out_dir.clone());
+    app.gen_completions("template", Shell::Bash, out_dir.clone());
+    app.gen_completions("template", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("template", Shell::Elvish, out_dir);
+}

--- a/tail/src/cli.rs
+++ b/tail/src/cli.rs
@@ -14,7 +14,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("FILE").help("File(s) to use.").multiple(true))
         .arg(
             Arg::with_name("bytes")
-                .help("Display the byte counts.")
+                .help("The total number of bytes to display from the end of the file.")
                 .long("bytes")
                 .short("c")
                 .value_name("N")
@@ -22,7 +22,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         )
         .arg(
             Arg::with_name("lines")
-                .help("Display the newline counts.")
+                .help("The total number of lines to display from the end of the file.")
                 .long("lines")
                 .short("n")
                 .value_name("N")

--- a/tail/src/cli.rs
+++ b/tail/src/cli.rs
@@ -11,9 +11,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .version_message("Display version information.")
         .help_short("?")
         .settings(&[ColoredHelp])
-        .arg(
-            Arg::with_name("FILE").help("File(s) to use.").multiple(true)
-        )
+        .arg(Arg::with_name("FILE").help("File(s) to use.").multiple(true))
         .arg(
             Arg::with_name("bytes")
                 .help("Display the byte counts.")

--- a/tail/src/cli.rs
+++ b/tail/src/cli.rs
@@ -1,0 +1,33 @@
+use clap::{
+    crate_authors, crate_description, crate_name, crate_version, App, AppSettings::ColoredHelp, Arg,
+};
+
+pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
+    App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .help_message("Display help information.")
+        .version_message("Display version information.")
+        .help_short("?")
+        .settings(&[ColoredHelp])
+        .arg(
+            Arg::with_name("FILE").help("File(s) to use.").multiple(true)
+        )
+        .arg(
+            Arg::with_name("bytes")
+                .help("Display the byte counts.")
+                .long("bytes")
+                .short("c")
+                .value_name("N")
+                .conflicts_with("lines"),
+        )
+        .arg(
+            Arg::with_name("lines")
+                .help("Display the newline counts.")
+                .long("lines")
+                .short("n")
+                .value_name("N")
+                .default_value("10"),
+        )
+}

--- a/tail/src/main.rs
+++ b/tail/src/main.rs
@@ -1,0 +1,160 @@
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, Read, Write},
+};
+
+use clap::{value_t, ArgMatches, ErrorKind};
+
+mod cli;
+
+const DEFAULT_LINES_COUNT: usize = 10;
+const NEW_LINE: u8 = 0xA;
+
+fn main() {
+    let matches = cli::create_app().get_matches();
+
+    let flags = Flags::from_matches(&matches);
+    let input_list = Input::from_matches(&matches);
+
+    tail(&flags, input_list).unwrap_or_else(|_e| {
+        std::process::exit(1);
+    });
+}
+
+/// We truncate the input at either some number of lines or bytes
+enum Flags {
+    LinesCount(usize),
+    BytesCount(usize),
+}
+
+impl Flags {
+    /// Parse arguments into a Flags enum
+    ///
+    /// This will exit the program early on invalid args
+    fn from_matches(matches: &ArgMatches) -> Self {
+        match value_t!(matches, "bytes", usize) {
+            Ok(bytes_count) => Flags::BytesCount(bytes_count),
+            Err(e) => match e.kind {
+                ErrorKind::ValueValidation => e.exit(),
+                _ => match value_t!(matches, "lines", usize) {
+                    Ok(l) => Flags::LinesCount(l),
+                    Err(e) => match e.kind {
+                        ErrorKind::ValueValidation => e.exit(),
+                        _ => Flags::LinesCount(DEFAULT_LINES_COUNT),
+                    },
+                },
+            },
+        }
+    }
+}
+
+/// Input is either a file, or STDIN
+enum Input {
+    File(String),
+    Stdin,
+}
+
+impl Input {
+    /// Parse arguments into an Vec of Input enums.
+    fn from_matches(matches: &ArgMatches) -> Vec<Self> {
+        if let Some(files) = matches.values_of("FILE") {
+            files
+                .map(|f| if f == "-" { Self::Stdin } else { Self::File(String::from(f)) })
+                .collect()
+        } else {
+            vec![Self::Stdin]
+        }
+    }
+}
+
+/// Return the tail of our input, truncated at a number of lines or bytes
+fn tail(flags: &Flags, input_list: Vec<Input>) -> Result<(), io::Error> {
+    let mut err_return = Ok(());
+    let files_count = input_list.len();
+
+    for (i, input) in input_list.iter().enumerate() {
+        if i > 0 {
+            println!();
+        }
+        match input {
+            Input::File(file) => {
+                let f = match File::open(file) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        eprintln!("tail: Cannot open '{}' for reading: {}", file, err);
+                        err_return = Err(err);
+                        continue;
+                    },
+                };
+
+                if files_count > 1 {
+                    println!("==> {} <==", file);
+                }
+                let reader = BufReader::new(f);
+                read_stream(flags, reader, &mut io::stdout())?;
+            },
+
+            Input::Stdin => {
+                if files_count > 1 {
+                    println!("==> standard input <==");
+                }
+                let stdin = io::stdin();
+                let reader = BufReader::new(stdin.lock());
+                read_stream(flags, reader, &mut io::stdout())?;
+            },
+        }
+    }
+
+    err_return
+}
+
+/// Read from a stream, truncated at a number of lines or bytes and write back to a stream
+fn read_stream<R: Read, W: Write>(
+    flags: &Flags, mut reader: BufReader<R>, writer: &mut W,
+) -> Result<(), io::Error> {
+    match flags {
+        Flags::LinesCount(lines_count) => {
+            for _ in 0..*lines_count {
+                let mut buffer = Vec::new();
+                let bytes_read = reader.read_until(NEW_LINE, &mut buffer)?;
+                if bytes_read == 0 {
+                    break;
+                }
+                writer.write_all(&buffer)?;
+            }
+        },
+        Flags::BytesCount(bytes_count) => {
+            let mut buffer = Vec::new();
+            reader.take(*bytes_count as u64).read_to_end(&mut buffer)?;
+            writer.write_all(&buffer)?;
+        },
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_stream_lines_count() {
+        let buffer = b"foo\nbar\nbaz";
+        let flags = Flags::LinesCount(2);
+        let mut out = Vec::new();
+
+        read_stream(&flags, BufReader::new(&buffer[..]), &mut out).unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "bar\nbaz\n".to_string());
+    }
+
+    #[test]
+    fn read_stream_bytes_count() {
+        let buffer = b"foo\nbar\nbaz";
+        let flags = Flags::BytesCount(2);
+        let mut out = Vec::new();
+
+        read_stream(&flags, BufReader::new(&buffer[..]), &mut out).unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "az".to_string());
+    }
+}

--- a/tail/src/main.rs
+++ b/tail/src/main.rs
@@ -151,7 +151,7 @@ fn read_stream<R: Read, W: Write>(
             reader.fill_buf()?;
             reader.consume(difference);
 
-            reader.take(*bytes_count as u64).read_to_end(&mut buffer)?;
+            reader.read_to_end(&mut buffer)?;
 
             writer.write_all(&buffer)?;
         },

--- a/tail/src/main.rs
+++ b/tail/src/main.rs
@@ -98,16 +98,16 @@ fn tail(flags: &Flags, input_list: Vec<Input>) -> io::Result<()> {
                     writeln!(writer, "==> standard input <==")?;
                 }
 
-                let stdin = io::stdin();
-                let reader = BufReader::new(stdin.lock());
+                let mut buffer = String::new();
+                let mut stdin = io::stdin();
+                stdin.read_to_string(&mut buffer)?;
 
-                // let count = match flags {
-                //     Flags::LinesCount(_) => line_count(file)?,
-                //     Flags::BytesCount(_) => byte_count(file)?,
-                // };
+                let reader = BufReader::new(buffer.as_bytes());
 
-                let count = 2;
-
+                let count = match flags {
+                    Flags::LinesCount(_) => lines_count_stdin(buffer.clone()),
+                    Flags::BytesCount(_) => byte_count_stdin(buffer.clone()),
+                };
 
                 read_stream(flags, reader, &mut writer, count)?;
             },
@@ -159,11 +159,23 @@ fn line_count(file_path: &str) -> io::Result<usize> {
     Ok(reader.lines().count())
 }
 
+fn lines_count_stdin(buffer: String) -> usize {
+    let reader = BufReader::new(buffer.as_bytes());
+
+    reader.lines().count()
+}
+
 fn byte_count(file_path: &str) -> io::Result<usize> {
     let file = File::open(file_path)?;
     let reader = BufReader::new(file);
 
     Ok(reader.bytes().count())
+}
+
+fn byte_count_stdin(buffer: String) -> usize {
+    let reader = BufReader::new(buffer.as_bytes());
+
+    reader.bytes().count()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR begins implementing the `tail` utility. The `-f` flag has not been implementing as I am unsure how to continuously consume input with `clap` and insert it into a buffer. The bulk of this implementation was copied from the preexisting `head` utility then repurposed to fit the needs of `tail`. Below lists which arguments were implemented.

* `-c`|`--bytes`
* `-n`|`--lines`