### PR TITLE
Create tee utility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/DragonflyBSD.toml
+++ b/DragonflyBSD.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/FreeBSD.toml
+++ b/FreeBSD.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/Fuchsia.toml
+++ b/Fuchsia.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/Haiku.toml
+++ b/Haiku.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/Linux.toml
+++ b/Linux.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/MacOS.toml
+++ b/MacOS.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/NetBSD.toml
+++ b/NetBSD.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/OpenBSD.toml
+++ b/OpenBSD.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cargo install --path .
 |   stat   |      X      |         |      |
 |   stty   |      X      |         |      |
 |   tail   |             |    X    |      |
-|   tee    |      X      |         |      |
+|   tee    |             |    X    |      |
 |   test   |      X      |         |      |
 |   time   |      X      |         |      |
 |  touch   |             |    X    |      |

--- a/Solaris.toml
+++ b/Solaris.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/Unix.toml
+++ b/Unix.toml
@@ -40,6 +40,7 @@ members = [
     "sleep",
     "sort",
     "tail",
+    "tee",
     "touch",
     "true",
     "tty",

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tee"
+version = "0.1.0"
+authors = ["Jeremy Jackson <git@jeremyvii.com>"]
+license = "MPL-2.0-no-copyleft-exception"
+build = "build.rs"
+edition = "2018"
+description = """
+Read from standard input and write to standard output or files.
+"""
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+clap = { version = "^2.33.0", features = ["wrap_help"] }
+
+[build-dependencies]
+clap = "^2.33.0"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -13,8 +13,10 @@ Read from standard input and write to standard output or files.
 
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
-assert_cmd = "1.0.2"
-tempfile = "3.1.0"
 
 [build-dependencies]
 clap = "^2.33.0"
+
+[dev-dependencies]
+assert_cmd = "1.0.2"
+tempfile = "3.1.0"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -14,6 +14,7 @@ Read from standard input and write to standard output or files.
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
 assert_cmd = "1.0.2"
+tempfile = "3.1.0"
 
 [build-dependencies]
 clap = "^2.33.0"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -13,6 +13,7 @@ Read from standard input and write to standard output or files.
 
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
+assert_cmd = "1.0.2"
 
 [build-dependencies]
 clap = "^2.33.0"

--- a/tee/Cargo.toml
+++ b/tee/Cargo.toml
@@ -13,6 +13,7 @@ Read from standard input and write to standard output or files.
 
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
+coreutils_core = { path = "../coreutils_core" }
 
 [build-dependencies]
 clap = "^2.33.0"

--- a/tee/build.rs
+++ b/tee/build.rs
@@ -1,0 +1,24 @@
+use std::env;
+
+use clap::Shell;
+
+#[path = "src/cli.rs"]
+mod cli;
+
+fn main() {
+    let mut app = cli::create_app();
+
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(dir) => dir,
+        Err(err) => {
+            eprintln!("No OUT_DIR: {}", err);
+            return;
+        },
+    };
+
+    app.gen_completions("template", Shell::Zsh, out_dir.clone());
+    app.gen_completions("template", Shell::Fish, out_dir.clone());
+    app.gen_completions("template", Shell::Bash, out_dir.clone());
+    app.gen_completions("template", Shell::PowerShell, out_dir.clone());
+    app.gen_completions("template", Shell::Elvish, out_dir);
+}

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -14,8 +14,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("FILE")
                 .help("File(s) to write to.")
-                .multiple(true)
-                .required_if("append", "true"),
+                .multiple(true),
         )
         .arg(
             Arg::with_name("append")

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -22,5 +22,4 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .short("a")
                 .long("append"),
         )
-        .arg(Arg::with_name("ignore").help("Ignore interrupt signals.").short("i").long("ignore"))
 }

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -1,0 +1,15 @@
+use clap::{
+    crate_authors, crate_description, crate_name, crate_version, App, AppSettings::ColoredHelp, Arg,
+};
+
+pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
+    App::new(crate_name!())
+        .version(crate_version!())
+        .author(crate_authors!())
+        .about(crate_description!())
+        .help_message("Display help information.")
+        .version_message("Display version information.")
+        .help_short("?")
+        .settings(&[ColoredHelp])
+    // Add args here
+}

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -18,5 +18,10 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .short("a")
                 .long("append"),
         )
-        .arg(Arg::with_name("ignore").help("Ignore interrupt signals.").short("i").long("ignore"))
+        .arg(
+            Arg::with_name("ignore_interrupts")
+                .help("Ignore interrupt signals.")
+                .short("i")
+                .long("ignore-interrupts"),
+        )
 }

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -11,5 +11,22 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .version_message("Display version information.")
         .help_short("?")
         .settings(&[ColoredHelp])
-    // Add args here
+        .arg(
+            Arg::with_name("FILE")
+                .help("File(s) to write to.")
+                .multiple(true)
+                .required_if("append", "true"),
+        )
+        .arg(
+            Arg::with_name("append")
+                .help("Append the output to the files.")
+                .short("a")
+                .long("append"),
+        )
+        .arg(
+            Arg::with_name("ignore")
+                .help("Ignore interrupt signals.")
+                .short("i")
+                .long("ignore")
+        )
 }

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -11,11 +11,7 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
         .version_message("Display version information.")
         .help_short("?")
         .settings(&[ColoredHelp])
-        .arg(
-            Arg::with_name("FILE")
-                .help("File(s) to write to.")
-                .multiple(true),
-        )
+        .arg(Arg::with_name("FILE").help("File(s) to write to.").multiple(true))
         .arg(
             Arg::with_name("append")
                 .help("Append the output to the files.")

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -18,4 +18,5 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .short("a")
                 .long("append"),
         )
+        .arg(Arg::with_name("ignore").help("Ignore interrupt signals.").short("i").long("ignore"))
 }

--- a/tee/src/cli.rs
+++ b/tee/src/cli.rs
@@ -23,10 +23,5 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .short("a")
                 .long("append"),
         )
-        .arg(
-            Arg::with_name("ignore")
-                .help("Ignore interrupt signals.")
-                .short("i")
-                .long("ignore")
-        )
+        .arg(Arg::with_name("ignore").help("Ignore interrupt signals.").short("i").long("ignore"))
 }

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -1,0 +1,11 @@
+use std::{
+    fs::File,
+    io::{self, BufRead, BufReader, BufWriter, Read, Write},
+};
+
+mod cli;
+
+fn main() {
+    let matches = cli::create_app().get_matches();
+}
+

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -109,3 +109,17 @@ impl Flags {
         Flags { append, ignore }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tee_test() {
+        let buffer = b"foo";
+        let mut out = Vec::new();
+
+        tee(BufReader::new(&buffer[..]), &mut out).unwrap();
+
+        assert_eq!(String::from_utf8(out).unwrap(), "foo".to_string());
+    }
+}

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -6,12 +6,18 @@ use std::{
 
 use clap::{ArgMatches, Values};
 
+use coreutils_core::libc::{signal, SIGINT, SIG_IGN};
+
 mod cli;
 
 fn main() {
     let matches = cli::create_app().get_matches();
     let flags = Flags::from_matches(&matches);
     let file_arg = matches.values_of("FILE");
+
+    if flags.ignore {
+        unsafe { signal(SIGINT, SIG_IGN) };
+    }
 
     let exit_code = process_input(file_arg, &flags);
 

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
-    fs::File,
-    io::{self, BufRead, BufReader, BufWriter, Read, Write},
+    fs::OpenOptions,
+    io::{self, BufReader, BufWriter, Read, Write},
     process,
 };
 
@@ -11,6 +11,7 @@ mod cli;
 fn main() {
     let matches = cli::create_app().get_matches();
     let flags = Flags::from_matches(&matches);
+    let mut exit_code = 0;
 
     let mut files: Vec<&str> = Vec::new();
 
@@ -23,6 +24,66 @@ fn main() {
             },
         };
     }
+
+    let mut input_buffer: Vec<u8> = Vec::new();
+    let mut stdin = io::stdin();
+    match stdin.read_to_end(&mut input_buffer) {
+        Ok(_) => {},
+        Err(err) => {
+            eprintln!("tee: {}", err);
+            process::exit(1);
+        },
+    }
+
+    if flags.append {
+        for path in files {
+            let file = match OpenOptions::new().read(true).write(true).create(true).open(path) {
+                Ok(file) => file,
+                Err(err) => {
+                    eprintln!("tee: {}", err);
+                    exit_code = 1;
+                    break;
+                },
+            };
+
+            let input = input_buffer.clone();
+            let reader: BufReader<&[u8]> = BufReader::new(input.as_ref());
+            let mut writer = BufWriter::new(file);
+
+            match tee(reader, &mut writer) {
+                Ok(_) => {},
+                Err(err) => {
+                    eprintln!("tee: {}", err);
+                    exit_code = 1;
+                    break;
+                },
+            };
+        }
+    } else {
+        let reader: BufReader<&[u8]> = BufReader::new(input_buffer.as_ref());
+
+        let mut writer = BufWriter::new(io::stdout());
+
+        match tee(reader, &mut writer) {
+            Ok(_) => {},
+            Err(err) => {
+                eprintln!("tee: {}", err);
+                exit_code = 1;
+            },
+        };
+    }
+
+    if exit_code != 0 {
+        process::exit(exit_code);
+    }
+}
+
+fn tee<R: Read, W: Write>(mut reader: BufReader<R>, writer: &mut W) -> io::Result<()> {
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer)?;
+    writer.write_all(&buffer)?;
+
+    Ok(())
 }
 
 struct Flags {

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -50,7 +50,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
 
     if flags.append {
         for path in files {
-            let file = match OpenOptions::new().write(true).create(true).open(path) {
+            let file = match OpenOptions::new().write(true).create(true).append(true).open(path) {
                 Ok(file) => file,
                 Err(err) => {
                     eprintln!("tee: {}", err);

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -1,11 +1,40 @@
 use std::{
     fs::File,
     io::{self, BufRead, BufReader, BufWriter, Read, Write},
+    process,
 };
+
+use clap::ArgMatches;
 
 mod cli;
 
 fn main() {
     let matches = cli::create_app().get_matches();
+    let flags = Flags::from_matches(&matches);
+
+    let mut files: Vec<&str> = Vec::new();
+
+    if flags.append {
+        files = match matches.values_of("FILE") {
+            Some(matches) => matches.collect(),
+            None => {
+                eprintln!("tee: no files provided");
+                process::exit(1);
+            },
+        };
+    }
 }
 
+struct Flags {
+    pub append: bool,
+    pub ignore: bool,
+}
+
+impl Flags {
+    pub fn from_matches(matches: &ArgMatches<'_>) -> Self {
+        let append = matches.is_present("append");
+        let ignore = matches.is_present("ignore");
+
+        Flags { append, ignore }
+    }
+}

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -42,7 +42,8 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
         Ok(_) => {},
         Err(err) => {
             eprintln!("tee: {}", err);
-            process::exit(1);
+            exit_code = 1;
+            return exit_code;
         },
     }
 
@@ -87,7 +88,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
     exit_code
 }
 
-/// Copies an input buffer reader to an output buffer reader.
+/// Writes the contents of input buffer reader to the provided writer.
 fn tee<R: Read, W: Write>(mut reader: BufReader<R>, writer: &mut W) -> io::Result<()> {
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer)?;

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
     let flags = Flags::from_matches(&matches);
     let file_arg = matches.values_of("FILE");
 
-    if flags.ignore {
+    if flags.ignore_interrupts {
         unsafe { signal(SIGINT, SIG_IGN) };
     }
 
@@ -106,15 +106,15 @@ fn copy_buffer<R: Read, W: Write>(mut reader: BufReader<R>, writer: &mut W) -> i
 
 struct Flags {
     pub append: bool,
-    pub ignore: bool,
+    pub ignore_interrupts: bool,
 }
 
 impl Flags {
     pub fn from_matches(matches: &ArgMatches<'_>) -> Self {
         let append = matches.is_present("append");
-        let ignore = matches.is_present("ignore");
+        let ignore_interrupts = matches.is_present("ignore");
 
-        Flags { append, ignore }
+        Flags { append, ignore_interrupts }
     }
 }
 

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -62,7 +62,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
             let reader: BufReader<&[u8]> = BufReader::new(input.as_ref());
             let mut writer = BufWriter::new(file);
 
-            match tee(reader, &mut writer) {
+            match copy_buffer(reader, &mut writer) {
                 Ok(_) => {},
                 Err(err) => {
                     eprintln!("tee: {}", err);
@@ -76,7 +76,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
 
         let mut writer = BufWriter::new(io::stdout());
 
-        match tee(reader, &mut writer) {
+        match copy_buffer(reader, &mut writer) {
             Ok(_) => {},
             Err(err) => {
                 eprintln!("tee: {}", err);
@@ -89,7 +89,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
 }
 
 /// Writes the contents of input buffer reader to the provided writer.
-fn tee<R: Read, W: Write>(mut reader: BufReader<R>, writer: &mut W) -> io::Result<()> {
+fn copy_buffer<R: Read, W: Write>(mut reader: BufReader<R>, writer: &mut W) -> io::Result<()> {
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer)?;
     writer.write_all(&buffer)?;
@@ -110,16 +110,17 @@ impl Flags {
         Flags { append, ignore }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn tee_test() {
+    fn copy_buffer_test() {
         let buffer = b"foo";
         let mut out = Vec::new();
 
-        tee(BufReader::new(&buffer[..]), &mut out).unwrap();
+        copy_buffer(BufReader::new(&buffer[..]), &mut out).unwrap();
 
         assert_eq!(String::from_utf8(out).unwrap(), "foo".to_string());
     }

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -31,7 +31,8 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
             Some(matches) => matches.collect(),
             None => {
                 eprintln!("tee: no files provided");
-                process::exit(1);
+                exit_code = 1;
+                return exit_code;
             },
         };
     }
@@ -49,7 +50,7 @@ fn process_input(file_arg: Option<Values>, flags: &Flags) -> i32 {
 
     if flags.append {
         for path in files {
-            let file = match OpenOptions::new().read(true).write(true).create(true).open(path) {
+            let file = match OpenOptions::new().write(true).create(true).open(path) {
                 Ok(file) => file,
                 Err(err) => {
                     eprintln!("tee: {}", err);

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -112,7 +112,7 @@ struct Flags {
 impl Flags {
     pub fn from_matches(matches: &ArgMatches<'_>) -> Self {
         let append = matches.is_present("append");
-        let ignore_interrupts = matches.is_present("ignore");
+        let ignore_interrupts = matches.is_present("ignore_interrupts");
 
         Flags { append, ignore_interrupts }
     }

--- a/tee/src/main.rs
+++ b/tee/src/main.rs
@@ -112,16 +112,4 @@ impl Flags {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn copy_buffer_test() {
-        let buffer = b"foo";
-        let mut out = Vec::new();
-
-        copy_buffer(BufReader::new(&buffer[..]), &mut out).unwrap();
-
-        assert_eq!(String::from_utf8(out).unwrap(), "foo".to_string());
-    }
-}
+mod tests;

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -1,9 +1,7 @@
 use super::*;
 use assert_cmd::Command;
-use std::{
-    error::Error,
-    fs::{remove_file, File, OpenOptions},
-};
+use std::{error::Error, fs::File};
+use tempfile::NamedTempFile;
 
 #[test]
 fn tee_copy_buffer() {
@@ -28,18 +26,16 @@ fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let test_file = "test_file";
+    let temp_file = NamedTempFile::new()?;
 
     let mut cmd = Command::cargo_bin("tee")?;
-    cmd.arg("-a").arg("test_file").write_stdin(buffer).output()?;
+    cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
-    let mut file = File::open(test_file)?;
+    let mut file = File::open(temp_file)?;
     let mut file_buffer = String::new();
     file.read_to_string(&mut file_buffer)?;
 
     assert_eq!(buffer.to_owned(), file_buffer);
-
-    remove_file(test_file)?;
 
     Ok(())
 }
@@ -47,21 +43,18 @@ fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let test_file = "test_file";
+    let mut temp_file = NamedTempFile::new()?;
 
-    let mut file = OpenOptions::new().read(true).write(true).create(true).open(test_file)?;
-    file.write_all(b"Test\n")?;
+    temp_file.write_all(b"Test\n")?;
 
     let mut cmd = Command::cargo_bin("tee")?;
-    cmd.arg("-a").arg("test_file").write_stdin(buffer).output()?;
+    cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
-    let mut file = File::open(test_file)?;
+    let mut file = File::open(temp_file)?;
     let mut file_buffer = String::from("Test\n");
     file.read_to_string(&mut file_buffer)?;
 
     assert_eq!("Test\nHello World!".to_owned(), file_buffer);
-
-    remove_file(test_file)?;
 
     Ok(())
 }

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -1,0 +1,67 @@
+use super::*;
+use assert_cmd::Command;
+use std::{
+    error::Error,
+    fs::{remove_file, File, OpenOptions},
+};
+
+#[test]
+fn tee_copy_buffer() {
+    let buffer = b"foo";
+    let mut out = Vec::new();
+
+    copy_buffer(BufReader::new(&buffer[..]), &mut out).unwrap();
+
+    assert_eq!(String::from_utf8(out).unwrap(), "foo".to_string());
+}
+
+#[test]
+fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
+    let buffer = "Hello World!";
+
+    let mut cmd = Command::cargo_bin("tee")?;
+    cmd.write_stdin(buffer).assert().stdout(buffer);
+
+    Ok(())
+}
+
+#[test]
+fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
+    let buffer = "Hello World!";
+    let test_file = "test_file";
+
+    let mut cmd = Command::cargo_bin("tee")?;
+    cmd.arg("-a").arg("test_file").write_stdin(buffer).output()?;
+
+    let mut file = File::open(test_file)?;
+    let mut file_buffer = String::new();
+    file.read_to_string(&mut file_buffer)?;
+
+    assert_eq!(buffer.to_owned(), file_buffer);
+
+    remove_file(test_file)?;
+
+    Ok(())
+}
+
+#[test]
+fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
+    let buffer = "Hello World!";
+    let test_file = "test_file";
+
+    let mut file = OpenOptions::new().read(true).write(true).create(true).open(test_file)?;
+    file.write_all(b"Test\n")?;
+
+    let mut cmd = Command::cargo_bin("tee")?;
+    cmd.arg("-a").arg("test_file").write_stdin(buffer).output()?;
+
+    let mut file = File::open(test_file)?;
+    let mut file_buffer = String::from("Test\n");
+    file.read_to_string(&mut file_buffer)?;
+
+    assert_eq!("Test\nHello World!".to_owned(), file_buffer);
+
+    remove_file(test_file)?;
+
+    Ok(())
+}

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -26,7 +26,7 @@ fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let temp_file = NamedTempFile::new()?;
 
     let mut cmd = Command::new("tee");
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
@@ -43,7 +43,7 @@ fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
+    let mut temp_file = NamedTempFile::new()?;
 
     temp_file.write_all(b"Test\n")?;
 

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -17,7 +17,7 @@ fn tee_copy_buffer() {
 fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
 
-    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
+    let mut cmd = Command::new("tee");
     cmd.write_stdin(buffer).assert().stdout(buffer);
 
     Ok(())
@@ -28,7 +28,7 @@ fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
     let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 
-    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
+    let mut cmd = Command::new("tee");
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
     let mut file = File::open(temp_file)?;
@@ -47,7 +47,7 @@ fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
 
     temp_file.write_all(b"Test\n")?;
 
-    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
+    let mut cmd = Command::new("tee");
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
     let mut file = File::open(temp_file)?;

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -51,7 +51,7 @@ fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
     let mut file = File::open(temp_file)?;
-    let mut file_buffer = String::from("Test\n");
+    let mut file_buffer = String::new();
     file.read_to_string(&mut file_buffer)?;
 
     assert_eq!("Test\nHello World!".to_owned(), file_buffer);

--- a/tee/src/tests.rs
+++ b/tee/src/tests.rs
@@ -17,7 +17,7 @@ fn tee_copy_buffer() {
 fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
 
-    let mut cmd = Command::cargo_bin("tee")?;
+    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
     cmd.write_stdin(buffer).assert().stdout(buffer);
 
     Ok(())
@@ -26,9 +26,9 @@ fn tee_copy_stdin_to_stdout() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let temp_file = NamedTempFile::new()?;
+    let temp_file = NamedTempFile::new().expect("Failed to create temp file");
 
-    let mut cmd = Command::cargo_bin("tee")?;
+    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
     let mut file = File::open(temp_file)?;
@@ -43,11 +43,11 @@ fn tee_copy_stdin_to_file() -> Result<(), Box<dyn Error>> {
 #[test]
 fn tee_append_stdin_to_file() -> Result<(), Box<dyn Error>> {
     let buffer = "Hello World!";
-    let mut temp_file = NamedTempFile::new()?;
+    let mut temp_file = NamedTempFile::new().expect("Failed to create temp file");
 
     temp_file.write_all(b"Test\n")?;
 
-    let mut cmd = Command::cargo_bin("tee")?;
+    let mut cmd = Command::cargo_bin("tee").expect("Failed retrieve binary");
     cmd.arg("-a").arg(temp_file.path()).write_stdin(buffer).output()?;
 
     let mut file = File::open(temp_file)?;


### PR DESCRIPTION
This PR begins implementing the `tee` utility. The `-i` flag has not been implemented, I was unsure how to best handle `SIGINT` and, unless I am misunderstanding the documentation, it seems that `write` ignores interrupts anyway. 

`-a`|`--append`