### PR TITLE
Time: Implement BSD extensions to time

### DIFF
--- a/coreutils_core/Cargo.toml
+++ b/coreutils_core/Cargo.toml
@@ -33,7 +33,7 @@ libc = { version = "~0.2.94", features = ["extra_traits"] }
 bstr = "~0.2.16"
 # bstr = {path = "/home/grayjack/MySources/RustProjects/bstr"}
 regex = "^1.5.2"
-time = "= 0.2.22"
+time = "= 0.2.23"
 
 [features]
 default = []

--- a/coreutils_core/src/os/resource.rs
+++ b/coreutils_core/src/os/resource.rs
@@ -78,7 +78,7 @@ impl From<rusage> for RUsage {
         RUsage {
             timing: Timing {
                 user_time: timeval_to_duration(ru.ru_utime),
-                sys_time: timeval_to_duration(ru.ru_stime)
+                sys_time: timeval_to_duration(ru.ru_stime),
             },
             mem: MemoryUsage {
                 max_rss: ru.ru_maxrss as u64,

--- a/coreutils_core/src/os/resource.rs
+++ b/coreutils_core/src/os/resource.rs
@@ -70,7 +70,12 @@ pub struct IOUsage {
 }
 
 fn timeval_to_duration(t: TimeVal) -> Duration {
-    Duration::new(t.tv_sec, t.tv_usec * 1_000)
+    // This type cast is realistically safe because the number of
+    // microseconds in a second cannot exceed `1e+6`, which at
+    // most would be `1e+9` nanoseconds, which fits in i32
+    // If this panics something really went wrong in the underlying
+    // C-api that returned this timeval
+    Duration::new(t.tv_sec as i64, t.tv_usec as i32 * 1_000)
 }
 
 impl From<rusage> for RUsage {

--- a/coreutils_core/src/os/resource.rs
+++ b/coreutils_core/src/os/resource.rs
@@ -4,6 +4,7 @@
 #[cfg(not(target_os = "fuchsia"))]
 use libc::getrusage;
 use libc::{c_int, rusage, RUSAGE_CHILDREN, RUSAGE_SELF};
+use time::Duration;
 
 use super::TimeVal;
 
@@ -27,9 +28,9 @@ pub struct RUsage {
 #[derive(Debug)]
 pub struct Timing {
     /// User CPU time used
-    pub user_time: TimeVal,
+    pub user_time: Duration,
     /// System CPU time used
-    pub sys_time: TimeVal,
+    pub sys_time: Duration,
 }
 
 #[derive(Debug)]
@@ -68,10 +69,17 @@ pub struct IOUsage {
     pub num_signals: u64,
 }
 
+fn timeval_to_duration(t: TimeVal) -> Duration {
+    Duration::new(t.tv_sec, t.tv_usec * 1_000)
+}
+
 impl From<rusage> for RUsage {
     fn from(ru: rusage) -> Self {
         RUsage {
-            timing: Timing { user_time: ru.ru_utime, sys_time: ru.ru_stime },
+            timing: Timing {
+                user_time: timeval_to_duration(ru.ru_utime),
+                sys_time: timeval_to_duration(ru.ru_stime)
+            },
             mem: MemoryUsage {
                 max_rss: ru.ru_maxrss as u64,
                 num_minor_page_flt: ru.ru_minflt as u64,

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "time"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Vaibhav Yenamandra <v@calloc.net>"]
 license = "MPL-2.0-no-copyleft-exception"
 build = "build.rs"

--- a/time/Cargo.toml
+++ b/time/Cargo.toml
@@ -10,6 +10,8 @@ description = "Run COMMAND, then display the system resource usage."
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
 coreutils_core = { path = "../coreutils_core" }
+indoc = "^1.0"
 
 [build-dependencies]
 clap = { version = "^2.33.0" }
+indoc = "^1.0"

--- a/time/src/cli.rs
+++ b/time/src/cli.rs
@@ -3,9 +3,55 @@ use clap::{
     AppSettings::{ColoredHelp, TrailingVarArg},
     Arg,
 };
+use indoc::indoc;
+
+const FMT_ARG_HELP: &str = indoc! {"
+    Specify a time format using the csh(1) time builtin syntax. The
+    following sequences are supported:
+    %U    The time the process spent in user mode in cpu seconds.
+    %S    The time the process spent in kernel mode in cpu seconds.
+    %E    The elapsed (wall clock) time in seconds.
+    %P    The CPU percentage computed as (%U + %S) / %E.
+    %W    Number of times the process was swapped.
+    %X    The average amount in (shared) text space used in Kbytes.
+    %D    The average amount in (unshared) data/stack space used in
+          Kbytes.
+    %K    The total space used (%X + %D) in Kbytes.
+    %M    The maximum memory the process had in use at any time in
+          Kbytes.
+    %F    The number of major page faults (page needed to be brought
+          from disk).
+    %R    The number of minor page faults.
+    %I    The number of input operations.
+    %O    The number of output operations.
+    %r    The number of socket messages received.
+    %s    The number of socket messages sent.
+    %k    The number of signals received.
+    %w    The number of voluntary context switches (waits).
+    %c    The number of involuntary context switches.
+"};
+
+const CSH_FMT_HELP: &str = indoc! {"
+    Displays information in the format used by default the time
+    builtin of csh(1) uses (%Uu  %Ss %E %P %X+%Dk %I+%Oio %Fpf+%Ww)
+"};
+
+const POSIX_FMT_HELP: &str = indoc! {"
+    Display time output in POSIX specified format as:
+        real %f
+        user %f
+        sys %f
+    Timer accuracy is arbitrary, but will always be counted in seconds.
+"};
+
+const TCSH_FMT_HELP: &str = indoc! {"
+    Displays information in the format used by default the time
+    builtin of tcsh(1) uses (%Uu %Ss %E %P\\t%X+%Dk %I+%Oio %Fpf+%Ww)
+    with three decimal places for time values.
+"};
 
 pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
-    App::new(crate_name!())
+    let app = App::new(crate_name!())
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
@@ -19,14 +65,46 @@ pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
                 .multiple(true)
                 .required(true),
         )
-        .arg(
-            Arg::with_name("posix")
-                .help(
-                    "Display time output in POSIX specified format as:\n\treal %f\n\tuser \
-                     %f\n\tsys  %f\nTimer accuracy is arbitrary, but will always be counted in \
-                     seconds.",
-                )
-                .long("posix")
-                .short("p"),
-        )
+        .arg(Arg::with_name("posix").help(POSIX_FMT_HELP).long("posix").short("p"));
+    configure_extensions(app)
+}
+
+#[rustfmt::skip]
+fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
+    let use_csh_fmt = Arg::with_name("use_csh_fmt")
+        .conflicts_with_all(&["posix"])
+        .help(CSH_FMT_HELP)
+        .long("csh-format")
+        .short("c");
+    let format_string = Arg::with_name("format_string")
+        .conflicts_with_all(&["posix", "use_csh_fmt"])
+        .takes_value(true)
+        .validator(|s: String| -> Result<(), String> {
+            if s.is_empty() || !s.is_ascii() {
+                Err(String::from("Format string must be non-empty ASCII"))
+            } else {
+                Ok(())
+            }
+        })
+        .help(FMT_ARG_HELP)
+        .long("format")
+        .short("f");
+    let use_tcsh_fmt = Arg::with_name("use_tcsh_fmt")
+        .conflicts_with_all(&["posix", "use_csh_fmt", "format_string"])
+        .help(TCSH_FMT_HELP)
+        .long("tcsh-format")
+        .short("t");
+
+    let dump_rusage = Arg::with_name("dump_rusage")
+        .conflicts_with_all(&["posix"])
+        .help("Lists resource utilization information. The contents of \
+              the\ncommand process's rusage structure are printed")
+        .long("rusage")
+        .short("l");
+
+    if cfg!(target_os = "netbsd") {
+        app.args(&[use_csh_fmt, format_string, dump_rusage, use_tcsh_fmt])
+    } else {
+        app
+    }
 }

--- a/time/src/cli.rs
+++ b/time/src/cli.rs
@@ -41,7 +41,7 @@ const POSIX_FMT_HELP: &str = indoc! {"
         real %f
         user %f
         sys %f
-    Timer accuracy is arbitrary, but will always be counted in seconds.
+    Timer accuracy is arbitrary, but will always be counted in seconds
 "};
 
 const TCSH_FMT_HELP: &str = indoc! {"
@@ -51,84 +51,93 @@ const TCSH_FMT_HELP: &str = indoc! {"
 "};
 
 pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
-    let app = App::new(crate_name!())
+    App::new(crate_name!())
         .version(crate_version!())
         .author(crate_authors!())
         .about(crate_description!())
-        .help_message("Display help information.")
-        .version_message("Display version information.")
+        .help_message("Display help information")
+        .version_message("Display version information")
         .help_short("?")
         .settings(&[ColoredHelp, TrailingVarArg])
         .arg(
             Arg::with_name("COMMAND")
-                .help("Command to run and it's arguments.")
+                .help("Command to run and it's arguments")
                 .multiple(true)
                 .required(true),
         )
-        .arg(Arg::with_name("posix").help(POSIX_FMT_HELP).long("posix").short("p"));
-    configure_extensions(app)
-}
-
-#[rustfmt::skip]
-fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
-    let use_csh_fmt = Arg::with_name("use_csh_fmt")
-        .conflicts_with_all(&["posix"])
-        .help(CSH_FMT_HELP)
-        .long("csh-format")
-        .short("c");
-    let format_string = Arg::with_name("format_string")
-        .conflicts_with_all(&["posix", "use_csh_fmt"])
-        .takes_value(true)
-        .validator(|s: String| -> Result<(), String> {
-            if s.is_empty() || !s.is_ascii() {
-                Err(String::from("Format string must be non-empty ASCII"))
-            } else {
-                Ok(())
-            }
-        })
-        .help(FMT_ARG_HELP)
-        .long("format")
-        .short("f");
-    let use_tcsh_fmt = Arg::with_name("use_tcsh_fmt")
-        .conflicts_with_all(&["posix", "use_csh_fmt", "format_string"])
-        .help(TCSH_FMT_HELP)
-        .long("tcsh-format")
-        .short("t");
-
-    let dump_rusage = Arg::with_name("dump_rusage")
-        .conflicts_with_all(&["posix"])
-        .help("Lists resource utilization information. The contents of \
-              the\ncommand process's rusage structure are printed")
-        .long("rusage")
-        .short("l");
-
-    let human_readable = Arg::with_name("human_readable")
-        .conflicts_with("posix")
-        .help("Time durations are printed in hours, minutes, seconds")
-        .long("human-readable")
-        .short("h");
-
-    let output_path = Arg::with_name("output_file")
-        .takes_value(true)
-        .help("Write the output to file instead of stderr.\
-              If file exists and the -a flag is not specified,\
-              the file will be overwritten.")
-        .long("output-path")
-        .short("o");
-
-    let append_output = Arg::with_name("append_mode")
-        .help("If the -o flag is used, append to specified file rather that\
-              overwrite it. Otherwise this option has no effect")
-        .long("append-mode")
-        .short("a");
-
-    if cfg!(target_os = "netbsd") {
-        app.args(&[use_csh_fmt, format_string, dump_rusage, use_tcsh_fmt])
-    } else if cfg!(any(target_os = "freebsd", target_os = "dragonflybsd")) {
-        app.args(&[append_output, dump_rusage, human_readable, output_path])
-    } else if cfg!(any(target_os = "openbsd", target_os = "macos")) {
-        app.arg(dump_rusage)
-    } else {
-        app
-    }
+        .arg(Arg::with_name("posix").help(POSIX_FMT_HELP).long("posix").short("p"))
+        .arg(
+            Arg::with_name("use_csh_fmt")
+                .conflicts_with_all(&["posix"])
+                .help("Display time output in POSIX format")
+                .long_help(CSH_FMT_HELP)
+                .long("csh-format")
+                .short("c"),
+        )
+        .arg(
+            Arg::with_name("format_string")
+                .conflicts_with_all(&["posix", "use_csh_fmt"])
+                .value_name("FORMAT_STRING")
+                .validator(|s: String| -> Result<(), String> {
+                    if s.is_empty() || !s.is_ascii() {
+                        Err(String::from("Format string must be non-empty ASCII"))
+                    } else {
+                        Ok(())
+                    }
+                })
+                .help("Specify a time format using the csh(1) time builtin syntax")
+                .long_help(FMT_ARG_HELP)
+                .long("format")
+                .short("f"),
+        )
+        .arg(
+            Arg::with_name("use_tcsh_fmt")
+                .conflicts_with_all(&["posix", "use_csh_fmt", "format_string"])
+                .help(
+                    "Displays information in the format used by default the time builtin of \
+                     tcsh(1)",
+                )
+                .long_help(TCSH_FMT_HELP)
+                .long("tcsh-format")
+                .short("t"),
+        )
+        .arg(
+            Arg::with_name("dump_rusage")
+                .conflicts_with_all(&["posix"])
+                .help("Lists resource utilization information")
+                .long_help(
+                    "Lists resource utilization information. The contents of the\ncommand \
+                     process's rusage structure are printed",
+                )
+                .long("rusage")
+                .short("l"),
+        )
+        .arg(
+            Arg::with_name("human_readable")
+                .conflicts_with("posix")
+                .help("Time durations are printed in hours, minutes, seconds")
+                .long("human-readable")
+                .short("h"),
+        )
+        .arg(
+            Arg::with_name("output_file")
+                .value_name("OUTPUT_FILE")
+                .help("Write the output to file instead of stderr")
+                .long_help(
+                    "Write the output to file instead of stderr.
+                     If file exists and the -a flag is not specified,the file will be overwritten",
+                )
+                .long("output-path")
+                .short("o"),
+        )
+        .arg(
+            Arg::with_name("append_mode")
+                .help("If the -o flag is used, append to the specified file")
+                .long_help(
+                    "If the -o flag is used, append to specified file rather than overwrite it. \
+                     Otherwise this option has no effect",
+                )
+                .long("append-mode")
+                .short("a"),
+        )
 }

--- a/time/src/cli.rs
+++ b/time/src/cli.rs
@@ -108,7 +108,7 @@ fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .long("human-readable")
         .short("h");
 
-    let output_path = Arg::with_name("output_path")
+    let output_path = Arg::with_name("output_file")
         .takes_value(true)
         .help("Write the output to file instead of stderr.\
               If file exists and the -a flag is not specified,\
@@ -116,16 +116,18 @@ fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .long("output-path")
         .short("o");
 
-    let append_output = Arg::with_name("append_output")
+    let append_output = Arg::with_name("append_mode")
         .help("If the -o flag is used, append to specified file rather that\
               overwrite it. Otherwise this option has no effect")
-        .long("append-output")
+        .long("append-mode")
         .short("a");
 
     if cfg!(target_os = "netbsd") {
         app.args(&[use_csh_fmt, format_string, dump_rusage, use_tcsh_fmt])
-    } else if cfg!(target_os = "freebsd") {
+    } else if cfg!(any(target_os = "freebsd", target_os = "dragonflybsd", target_os = "macos")) {
         app.args(&[append_output, dump_rusage, human_readable, output_path])
+    } else if cfg!(any(target_os = "openbsd", target_os = "macos")) {
+        app.arg(dump_rusage)
     } else {
         app
     }

--- a/time/src/cli.rs
+++ b/time/src/cli.rs
@@ -124,7 +124,7 @@ fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
 
     if cfg!(target_os = "netbsd") {
         app.args(&[use_csh_fmt, format_string, dump_rusage, use_tcsh_fmt])
-    } else if cfg!(any(target_os = "freebsd", target_os = "dragonflybsd", target_os = "macos")) {
+    } else if cfg!(any(target_os = "freebsd", target_os = "dragonflybsd")) {
         app.args(&[append_output, dump_rusage, human_readable, output_path])
     } else if cfg!(any(target_os = "openbsd", target_os = "macos")) {
         app.arg(dump_rusage)

--- a/time/src/cli.rs
+++ b/time/src/cli.rs
@@ -102,8 +102,30 @@ fn configure_extensions<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         .long("rusage")
         .short("l");
 
+    let human_readable = Arg::with_name("human_readable")
+        .conflicts_with("posix")
+        .help("Time durations are printed in hours, minutes, seconds")
+        .long("human-readable")
+        .short("h");
+
+    let output_path = Arg::with_name("output_path")
+        .takes_value(true)
+        .help("Write the output to file instead of stderr.\
+              If file exists and the -a flag is not specified,\
+              the file will be overwritten.")
+        .long("output-path")
+        .short("o");
+
+    let append_output = Arg::with_name("append_output")
+        .help("If the -o flag is used, append to specified file rather that\
+              overwrite it. Otherwise this option has no effect")
+        .long("append-output")
+        .short("a");
+
     if cfg!(target_os = "netbsd") {
         app.args(&[use_csh_fmt, format_string, dump_rusage, use_tcsh_fmt])
+    } else if cfg!(target_os = "freebsd") {
+        app.args(&[append_output, dump_rusage, human_readable, output_path])
     } else {
         app
     }

--- a/time/src/flags.rs
+++ b/time/src/flags.rs
@@ -47,9 +47,9 @@ impl TimeOpts {
                 let kind = if args.is_present("posix") {
                     FormatterKind::Posix
                 } else if args.is_present("use_csh_fmt") {
-                    FormatterKind::CSH
+                    FormatterKind::Csh
                 } else if args.is_present("use_tcsh_fmt") {
-                    FormatterKind::TCSH
+                    FormatterKind::TCsh
                 } else if args.is_present("format_string") {
                     FormatterKind::FmtString(
                         args.value_of("format_string").expect("Empty format string").to_owned(),

--- a/time/src/flags.rs
+++ b/time/src/flags.rs
@@ -4,7 +4,10 @@ use std::{fs::OpenOptions, io, path::PathBuf};
 
 use clap::ArgMatches;
 
-use crate::{cli::create_app, output::FormatterKind, output::OutputFormatter};
+use crate::{
+    cli::create_app,
+    output::{FormatterKind, OutputFormatter},
+};
 
 // Condense CLI args as a struct
 #[derive(Debug)]
@@ -54,10 +57,7 @@ impl TimeOpts {
                 } else {
                     FormatterKind::Default
                 };
-                OutputFormatter {
-                    kind,
-                    human_readable: args.is_present("human_readable")
-                }
+                OutputFormatter { kind, human_readable: args.is_present("human_readable") }
             },
             command: args
                 .values_of("COMMAND")

--- a/time/src/flags.rs
+++ b/time/src/flags.rs
@@ -22,6 +22,14 @@ impl TimeOpts {
         TimeOpts {
             printer: if args.is_present("posix") {
                 OutputFormatter::Posix
+            } else if args.is_present("use_csh_fmt") {
+                OutputFormatter::CSH
+            } else if args.is_present("use_tcsh_fmt") {
+                OutputFormatter::TCSH
+            } else if args.is_present("format_string") {
+                OutputFormatter::FmtString(
+                    args.value_of("format_string").expect("Empty format string").to_owned(),
+                )
             } else {
                 OutputFormatter::Default
             },

--- a/time/src/flags.rs
+++ b/time/src/flags.rs
@@ -17,9 +17,9 @@ pub struct TimeOpts {
     /// Command as seen on the CLI
     pub command: Vec<String>,
     /// Where the output should be written to
-    pub destination: Option<PathBuf>,
+    destination: Option<PathBuf>,
     /// Should the destination be appended to?
-    pub append: bool,
+    append: bool,
 }
 
 impl TimeOpts {

--- a/time/src/main.rs
+++ b/time/src/main.rs
@@ -14,6 +14,14 @@ fn main() {
 
     let usage = get_rusage(ResourceConsumer::Children);
 
-    eprintln!("{}", opts.printer.format_stats(&usage, &duration));
+    let written = match opts.get_output_stream() {
+        Ok(mut stream) => {
+            let data = opts.printer.format_stats(&usage, &duration);
+            stream.write(data.as_bytes())
+        },
+        Err(err) => Err(err),
+    };
+
+    written.err().map(subprocess::exit_with_msg);
     std::process::exit(exit_status.code().unwrap_or(1));
 }

--- a/time/src/main.rs
+++ b/time/src/main.rs
@@ -22,6 +22,8 @@ fn main() {
         Err(err) => Err(err),
     };
 
-    written.err().map(subprocess::exit_with_msg);
+    if let Err(err) = written {
+        subprocess::exit_with_msg(err);
+    }
     std::process::exit(exit_status.code().unwrap_or(1));
 }

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -1,11 +1,16 @@
 //! Output interface for `time`
 
+use std::fmt::Write;
+
 use coreutils_core::os::{resource::RUsage, TimeVal};
 
 #[derive(Debug, PartialEq)]
 pub enum OutputFormatter {
     Default,
     Posix,
+    CSH,
+    TCSH,
+    FmtString(String),
 }
 
 /// Express `coreutils_core::os::TimeVal` into `f64` seconds
@@ -13,20 +18,144 @@ fn as_secs_f64(tv: TimeVal) -> f64 {
     tv.tv_sec as f64 + (tv.tv_usec as f64) / 1_000_000.0
 }
 
+// Convenience struct for passing 3 floating point parameters
+struct TimeTriple {
+    pub user_time: f64,
+    pub sys_time: f64,
+    pub wall_time: f64,
+}
+
 impl OutputFormatter {
     pub fn format_stats(self, rusage: &RUsage, duration: &std::time::Duration) -> String {
-        let wall_time = duration.as_secs_f64();
-        let user_time = as_secs_f64(rusage.timing.user_time);
-        let sys_time = as_secs_f64(rusage.timing.sys_time);
+        let timings: TimeTriple = TimeTriple {
+            user_time: as_secs_f64(rusage.timing.user_time),
+            sys_time: as_secs_f64(rusage.timing.sys_time),
+            wall_time: duration.as_secs_f64(),
+        };
         match self {
-            OutputFormatter::Default => default_formatter(rusage, wall_time, user_time, sys_time),
+            OutputFormatter::Default => default_formatter(rusage, timings),
             OutputFormatter::Posix => {
-                format!("real {:.2}\nuser {:.2}\nsys  {:.2}", wall_time, user_time, sys_time)
+                format!(
+                    "real {:.2}\nuser {:.2}\nsys  {:.2}",
+                    timings.wall_time, timings.user_time, timings.sys_time
+                )
             },
+            OutputFormatter::CSH => csh_formatter(rusage, timings),
+            OutputFormatter::TCSH => tcsh_formatter(rusage, timings),
+            OutputFormatter::FmtString(spec) => custom_formatter(rusage, timings, &spec),
         }
     }
 }
 
-pub fn default_formatter(_: &RUsage, wall_time: f64, user_time: f64, sys_time: f64) -> String {
-    format!("{:.2} real {:.2} user {:.2} sys", wall_time, user_time, sys_time)
+fn default_formatter(_: &RUsage, timings: TimeTriple) -> String {
+    format!(
+        "{:.2} real {:.2} user {:.2} sys",
+        timings.wall_time, timings.user_time, timings.sys_time
+    )
+}
+
+/// Render the <specifier> in %<specifier>, return a pair of boolean and the rendered
+/// The boolean signals if the specifier was rendered
+fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: char) -> Option<String> {
+    match spec {
+        'c' => Some(rusage.mem.num_invol_ctx_switch.to_string()),
+        'D' => Some(rusage.mem.unshared_data_size.to_string()),
+        'E' => Some(format!("{:.2}", timings.wall_time)),
+        'F' => Some(rusage.mem.num_major_page_flt.to_string()),
+        'I' => Some(rusage.io.num_block_in.to_string()),
+        'K' => Some(
+            (rusage.mem.shared_mem_size
+                + rusage.mem.unshared_data_size
+                + rusage.mem.unshared_stack_size)
+                .to_string(),
+        ),
+        'k' => Some(rusage.io.num_signals.to_string()),
+        'M' => Some(rusage.mem.max_rss.to_string()),
+        'O' => Some(rusage.mem.max_rss.to_string()),
+        'P' => {
+            if timings.wall_time == 0_f64 {
+                Some(String::from("0.0%"))
+            } else {
+                Some(format!("{:.2}", (timings.user_time + timings.sys_time) / timings.wall_time))
+            }
+        },
+        'R' => Some(rusage.mem.num_minor_page_flt.to_string()),
+        'r' => Some(rusage.io.num_sock_recv.to_string()),
+        'S' => Some(format!("{:.2}", timings.sys_time)),
+        's' => Some(rusage.io.num_sock_send.to_string()),
+        'U' => Some(format!("{:.2}", timings.user_time)),
+        'W' => Some(rusage.mem.num_swaps.to_string()),
+        'w' => Some(rusage.mem.num_vol_ctx_switch.to_string()),
+        'X' => {
+            if timings.wall_time == 0_f64 {
+                Some(String::from("0.0%"))
+            } else {
+                Some(rusage.mem.shared_mem_size.to_string())
+            }
+        },
+        _ => None,
+    }
+}
+
+fn custom_formatter(rusage: &RUsage, timings: TimeTriple, format_spec: &str) -> String {
+    assert!(format_spec.is_ascii(), "Format string spec contains non-ascii characters");
+    let mut target = String::new();
+    // let characters: Vec<char> = format_spec.chars().collect();
+
+    let mut format_spec_iterator = format_spec.chars().peekable();
+
+    while let Some(ch) = format_spec_iterator.next() {
+        if ch != '%' {
+            write!(&mut target, "{}", ch).expect("Failed to write to format buffer");
+        } else {
+            match format_spec_iterator.peek() {
+                Some(&specifier) => {
+                    if let Some(text) = render_percent_spec(rusage, &timings, specifier) {
+                        write!(&mut target, "{}", text).expect("Failed to write to format buffer");
+                    } else {
+                        write!(&mut target, "%{}", specifier)
+                            .expect("Failed to write to format buffer");
+                    }
+                    // Skip this character, we have dealt with the result of .peek()
+                    format_spec_iterator.next();
+                },
+                None => {
+                    write!(&mut target, "%").expect("Failed to write to format buffer");
+                },
+            }
+        }
+    }
+    target
+}
+
+fn csh_formatter(rusage: &RUsage, timings: TimeTriple) -> String {
+    format!(
+        "{:.2}u {:.2}s {:.2} {:.2} {}+{}k {}+{}io {}pf+{}w",
+        timings.user_time,
+        timings.sys_time,
+        timings.wall_time,
+        (timings.user_time + timings.sys_time) / timings.wall_time,
+        rusage.mem.shared_mem_size,
+        rusage.mem.unshared_stack_size,
+        rusage.io.num_block_in,
+        rusage.io.num_block_out,
+        rusage.mem.num_major_page_flt,
+        rusage.mem.num_swaps,
+    )
+}
+
+fn tcsh_formatter(rusage: &RUsage, timings: TimeTriple) -> String {
+    format!(
+        "{:.2}u {:.2}s {:.2} {:.2}\t{}+{}k {}+{}io {}pf+{}w",
+        timings.user_time,
+        timings.sys_time,
+        timings.wall_time,
+        (timings.user_time + timings.sys_time) / timings.wall_time,
+        rusage.mem.shared_mem_size,
+        rusage.mem.unshared_stack_size,
+        rusage.io.num_block_in,
+        rusage.io.num_block_out,
+        rusage.mem.num_major_page_flt,
+        rusage.mem.num_swaps,
+    )
 }

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -25,13 +25,13 @@ pub enum FormatterKind {
     /// ```
     /// %Uu %Ss %E %P %X+%Dk %I+%Oio %Fpf+%Ww
     /// ```
-    CSH,
+    Csh,
 
     /// Display time output in the tcsh(1) default format:
     /// ```
     /// %Uu %Ss %E %P\t%X+%Dk %I+%Oio %Fpf+%Ww
     /// ```
-    TCSH,
+    TCsh,
 
     /// Use a custom format string to render the output using printf-style
     /// `%<specifier>` markers. Supported markers are:
@@ -100,8 +100,8 @@ impl OutputFormatter {
                     timings.sys_time.as_seconds_f64()
                 )
             },
-            FormatterKind::CSH => csh_formatter(rusage, timings),
-            FormatterKind::TCSH => tcsh_formatter(rusage, timings),
+            FormatterKind::Csh => csh_formatter(rusage, timings),
+            FormatterKind::TCsh => tcsh_formatter(rusage, timings),
             FormatterKind::FmtString(spec) => custom_formatter(rusage, timings, &spec),
         }
     }

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -1,8 +1,8 @@
 //! The Output interface for `time` is detailed in this module
 
-use coreutils_core::time::Duration;
 use std::fmt::Write;
-use coreutils_core::os::resource::RUsage;
+
+use coreutils_core::{os::resource::RUsage, time::Duration};
 
 /// The `FormatterKind` enum is how `time` controls the printing
 /// of timing and resource usage information

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -15,7 +15,7 @@ pub enum OutputFormatter {
 
 /// Express `coreutils_core::os::TimeVal` into `f64` seconds
 fn as_secs_f64(tv: TimeVal) -> f64 {
-    tv.tv_sec as f64 + (tv.tv_usec as f64) / 1_000_000.0
+    tv.tv_sec as f64 + (tv.tv_usec as f64) / 1e+6
 }
 
 // Convenience struct for passing 3 floating point parameters
@@ -56,37 +56,37 @@ fn default_formatter(_: &RUsage, timings: TimeTriple) -> String {
 
 /// Render the <specifier> in %<specifier>, return a pair of boolean and the rendered
 /// The boolean signals if the specifier was rendered
-fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: char) -> Option<String> {
+fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: u8) -> Option<String> {
     match spec {
-        'c' => Some(rusage.mem.num_invol_ctx_switch.to_string()),
-        'D' => Some(rusage.mem.unshared_data_size.to_string()),
-        'E' => Some(format!("{:.2}", timings.wall_time)),
-        'F' => Some(rusage.mem.num_major_page_flt.to_string()),
-        'I' => Some(rusage.io.num_block_in.to_string()),
-        'K' => Some(
+        b'c' => Some(rusage.mem.num_invol_ctx_switch.to_string()),
+        b'D' => Some(rusage.mem.unshared_data_size.to_string()),
+        b'E' => Some(format!("{:.2}", timings.wall_time)),
+        b'F' => Some(rusage.mem.num_major_page_flt.to_string()),
+        b'I' => Some(rusage.io.num_block_in.to_string()),
+        b'K' => Some(
             (rusage.mem.shared_mem_size
                 + rusage.mem.unshared_data_size
                 + rusage.mem.unshared_stack_size)
                 .to_string(),
         ),
-        'k' => Some(rusage.io.num_signals.to_string()),
-        'M' => Some(rusage.mem.max_rss.to_string()),
-        'O' => Some(rusage.mem.max_rss.to_string()),
-        'P' => {
+        b'k' => Some(rusage.io.num_signals.to_string()),
+        b'M' => Some(rusage.mem.max_rss.to_string()),
+        b'O' => Some(rusage.mem.max_rss.to_string()),
+        b'P' => {
             if timings.wall_time == 0_f64 {
                 Some(String::from("0.0%"))
             } else {
                 Some(format!("{:.2}", (timings.user_time + timings.sys_time) / timings.wall_time))
             }
         },
-        'R' => Some(rusage.mem.num_minor_page_flt.to_string()),
-        'r' => Some(rusage.io.num_sock_recv.to_string()),
-        'S' => Some(format!("{:.2}", timings.sys_time)),
-        's' => Some(rusage.io.num_sock_send.to_string()),
-        'U' => Some(format!("{:.2}", timings.user_time)),
-        'W' => Some(rusage.mem.num_swaps.to_string()),
-        'w' => Some(rusage.mem.num_vol_ctx_switch.to_string()),
-        'X' => {
+        b'R' => Some(rusage.mem.num_minor_page_flt.to_string()),
+        b'r' => Some(rusage.io.num_sock_recv.to_string()),
+        b'S' => Some(format!("{:.2}", timings.sys_time)),
+        b's' => Some(rusage.io.num_sock_send.to_string()),
+        b'U' => Some(format!("{:.2}", timings.user_time)),
+        b'W' => Some(rusage.mem.num_swaps.to_string()),
+        b'w' => Some(rusage.mem.num_vol_ctx_switch.to_string()),
+        b'X' => {
             if timings.wall_time == 0_f64 {
                 Some(String::from("0.0%"))
             } else {
@@ -97,23 +97,66 @@ fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: char) -> Opt
     }
 }
 
-fn custom_formatter(rusage: &RUsage, timings: TimeTriple, format_spec: &str) -> String {
-    assert!(format_spec.is_ascii(), "Format string spec contains non-ascii characters");
-    let mut target = String::new();
-    // let characters: Vec<char> = format_spec.chars().collect();
+/// Internal: Unescapes a backslash escaped string
+/// See: https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
+fn decode_escaped_string(value: String) -> String {
+    let mut iter = value.bytes().peekable();
+    let mut output = String::new();
 
-    let mut format_spec_iterator = format_spec.chars().peekable();
+    while let Some(ch) = iter.next() {
+        if ch == b'\\' {
+            if let Some(next_ch) = iter.peek() {
+                // Find out which of the escape codes was used to decide
+                // which byte to write next. If none of the escape codes match,
+                // write the backslash that was going to be skipped instead
+                let (decode_successful, byte_to_write): (bool, u8) = match next_ch {
+                    b'a' => (true, 0x07),
+                    b'b' => (true, 0x08),
+                    b'e' => (true, 0x1B),
+                    b'f' => (true, 0x0C),
+                    b'n' => (true, 0x0A),
+                    b'r' => (true, 0x0D),
+                    b't' => (true, 0x09),
+                    b'v' => (true, 0x0B),
+                    b'\\' => (true, 0x5C),
+                    b'\'' => (true, 0x27),
+                    b'\"' => (true, 0x22),
+                    b'?' => (true, 0x3F),
+                    _ => (false, b'\\'),
+                };
+
+                write!(output, "{}", byte_to_write as char).expect("Failed to unescape string");
+                // If a byte was decoded, skip over it.
+                // Otherwise, write out the backslash
+                if decode_successful {
+                    iter.next();
+                }
+            } else {
+                panic!("Invalid escape '\\' at end of input");
+            }
+        } else {
+            write!(output, "{}", ch as char).expect("Failed to unescape string");
+        }
+    }
+    output
+}
+
+fn custom_formatter(rusage: &RUsage, timings: TimeTriple, format_spec: &str) -> String {
+    let mut target = String::new();
+    let unescaped_spec = decode_escaped_string(format_spec.to_owned());
+    let mut format_spec_iterator = unescaped_spec.bytes().peekable();
 
     while let Some(ch) = format_spec_iterator.next() {
-        if ch != '%' {
-            write!(&mut target, "{}", ch).expect("Failed to write to format buffer");
+        if ch != b'%' {
+            write!(&mut target, "{}", ch as char).expect("Failed to write to format buffer");
         } else {
             match format_spec_iterator.peek() {
                 Some(&specifier) => {
                     if let Some(text) = render_percent_spec(rusage, &timings, specifier) {
                         write!(&mut target, "{}", text).expect("Failed to write to format buffer");
                     } else {
-                        write!(&mut target, "%{}", specifier)
+                        // If the %<char> wasn't rendered, dump it out as it was seen
+                        write!(&mut target, "%{}", specifier as char)
                             .expect("Failed to write to format buffer");
                     }
                     // Skip this character, we have dealt with the result of .peek()

--- a/time/src/subprocess.rs
+++ b/time/src/subprocess.rs
@@ -1,6 +1,6 @@
+use std::io;
 /// Module for creating, and interacting with child processes
 use std::process::{exit, Command, ExitStatus, Stdio};
-use std::io;
 
 use coreutils_core::time::{Duration, Instant};
 

--- a/time/src/subprocess.rs
+++ b/time/src/subprocess.rs
@@ -1,9 +1,8 @@
 /// Module for creating, and interacting with child processes
 use std::process::{exit, Command, ExitStatus, Stdio};
-use std::{
-    io,
-    time::{Duration, Instant},
-};
+use std::io;
+
+use coreutils_core::time::{Duration, Instant};
 
 type SubprocessTiming = (ExitStatus, Duration);
 

--- a/touch/Cargo.toml
+++ b/touch/Cargo.toml
@@ -15,7 +15,7 @@ associated with standard output.
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
 filetime = "~0.2.9"
-time = "= 0.2.22"
+time = "= 0.2.23"
 
 [build-dependencies]
 clap = "^2.33.0"


### PR DESCRIPTION
Provides:
- [X] `-f`: Format stats with an arbitrary printf-like `%<spec>` formatters 
- [X] `-t`: Format stats using the `tcsh(1)` format string
  - See: https://man.netbsd.org/time.1
- [X] `-c`: Write `time` stats in the `csh(1)` format string
  - See: https://man.netbsd.org/time.1
- [ ] `-l`: Dump the contents of the `rusage` struct (⚠️ Unimplemented as of this PR)
- [X] `-a`: If `-o` was provided, append to the target file instead of truncating
- [X] `-o`: Create, truncate a file to write `time` output to.

Part of: #53 