### PR TITLE
Seq: Major rewrite

### DIFF
--- a/seq/Cargo.toml
+++ b/seq/Cargo.toml
@@ -12,10 +12,6 @@ Display numbers from FIRST to LAST, in steps of INCREMENT.
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
-sugars = "^3.0.0"
-
-[dev-dependencies]
-assert_cmd = "1.0.2"
 
 [build-dependencies]
 clap = "^2.33.0"

--- a/seq/Cargo.toml
+++ b/seq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seq"
 version = "0.1.0"
-authors = ["John Pradeep Vincent <yehohanan7@gmail.com>"]
+authors = ["John Pradeep Vincent <yehohanan7@gmail.com>", "gahag <gabriel.s.b@live.com>"]
 license = "MPL-2.0-no-copyleft-exception"
 build = "build.rs"
 edition = "2018"

--- a/seq/src/args.rs
+++ b/seq/src/args.rs
@@ -1,0 +1,176 @@
+use std::fmt::{self, Display};
+
+use super::float;
+
+
+#[derive(Debug)]
+pub(crate) enum Error<'a> {
+    InvalidIncrement(&'a str),
+    InvalidFloat(&'a str),
+    MissingOperand,
+    TrailingOperand(&'a str),
+}
+
+
+impl<'a> Display for Error<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::InvalidIncrement(increment) => write!(f, "invalid increment '{}'", increment),
+            Self::InvalidFloat(input) => write!(f, "invalid floating point argument '{}'", input),
+            Self::MissingOperand => write!(f, "missing operand"),
+            Self::TrailingOperand(operand) => write!(f, "extra operand '{}'", operand),
+        }
+    }
+}
+
+
+impl<'a> std::error::Error for Error<'a> {}
+
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Args<'a> {
+    pub first: f64,
+    pub increment: f64,
+    pub last: f64,
+    pub decimals: usize,
+    pub padding: Option<usize>,
+    pub separator: &'a str,
+    pub terminator: &'a str,
+}
+
+
+impl<'a> Args<'a> {
+    pub fn parse(matches: &'a clap::ArgMatches<'a>) -> Result<Self, Error<'a>> {
+        let operands: Vec<&str> =
+            matches.values_of("FIRST INCREMENT LAST").ok_or(Error::MissingOperand)?.collect();
+
+        let (first, increment, last) = Self::parse_operands(&operands)?;
+
+        let decimals = operands
+            .iter()
+            .copied()
+            .map(float::count_decimal_digits)
+            .max()
+            .ok_or(Error::MissingOperand)?;
+
+        let padding = if matches.is_present("WIDTH") {
+            let padding = operands
+                .iter()
+                .copied()
+                .map(float::count_integer_digits)
+                .max()
+                .ok_or(Error::MissingOperand)?;
+
+            Some(padding)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            first,
+            increment,
+            last,
+
+            decimals,
+            padding,
+
+            separator: matches
+                .value_of("SEPARATOR")
+                .expect("missing default argument for separator"),
+
+            terminator: matches
+                .value_of("TERMINATOR")
+                .expect("missing default argument for terminator"),
+        })
+    }
+
+    fn parse_operands(operands: &[&'a str]) -> Result<(f64, f64, f64), Error<'a>> {
+        match operands {
+            [] => Err(Error::MissingOperand),
+
+            [last] => {
+                let last = Self::parse_float(last)?;
+                Ok((1.0, 1.0, last))
+            },
+
+            [first, last] => {
+                let first = Self::parse_float(first)?;
+                let last = Self::parse_float(last)?;
+                Ok((first, 1.0, last))
+            },
+
+            [first, inc, last] => {
+                let first = Self::parse_float(first)?;
+                let increment = Self::parse_float(inc)?;
+                let last = Self::parse_float(last)?;
+
+                if increment == 0.0 {
+                    Err(Error::InvalidIncrement(inc))
+                } else {
+                    Ok((first, increment, last))
+                }
+            },
+
+            [_, _, _, trailing, ..] => Err(Error::TrailingOperand(trailing)),
+        }
+    }
+
+    fn parse_float(arg: &str) -> Result<f64, Error> {
+        arg.parse().map_err(|_| Error::InvalidFloat(arg))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use crate::cli;
+
+
+    fn test_input<I, T>(iterator: I, expected: &Args)
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let matches = cli::create_app().get_matches_from(iterator);
+        let args = Args::parse(&matches).expect("failed to parse matches");
+
+        assert_eq!(&args, expected);
+    }
+
+
+    #[test]
+    fn test_parsing_input() {
+        test_input(&["seq", "1", "1", "4"], &Args {
+            first: 1.0,
+            increment: 1.0,
+            last: 4.0,
+            decimals: 0,
+            padding: None,
+            separator: "\n",
+            terminator: "\n",
+        });
+
+        test_input(&["seq", "2", "10"], &Args {
+            first: 2.0,
+            increment: 1.0,
+            last: 10.0,
+            decimals: 0,
+            padding: None,
+            separator: "\n",
+            terminator: "\n",
+        });
+
+        test_input(&["seq", "3"], &Args {
+            first: 1.0,
+            increment: 1.0,
+            last: 3.0,
+            decimals: 0,
+            padding: None,
+            separator: "\n",
+            terminator: "\n",
+        });
+    }
+}

--- a/seq/src/cli.rs
+++ b/seq/src/cli.rs
@@ -2,6 +2,7 @@ use clap::{
     crate_authors, crate_description, crate_name, crate_version, App, AppSettings::ColoredHelp, Arg,
 };
 
+
 pub(crate) fn create_app<'a, 'b>() -> App<'a, 'b> {
     App::new(crate_name!())
         .version(crate_version!())

--- a/seq/src/float.rs
+++ b/seq/src/float.rs
@@ -1,0 +1,40 @@
+pub(crate) fn count_integer_digits(float: &str) -> usize {
+    float.find('.').unwrap_or_else(|| float.len())
+}
+
+
+pub(crate) fn count_decimal_digits(float: &str) -> usize {
+    let len = float.len();
+
+    let decimal = float.find('.').map(|pos| pos + 1).unwrap_or(len);
+
+    len - decimal
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+
+    #[test]
+    fn test_count_integer_digits() {
+        assert_eq!(count_integer_digits("42"), 2);
+        assert_eq!(count_integer_digits("12.22"), 2);
+        assert_eq!(count_integer_digits("1.22"), 1);
+        assert_eq!(count_integer_digits("1.3"), 1);
+        assert_eq!(count_integer_digits("1"), 1);
+        assert_eq!(count_integer_digits("-152.3"), 4); // Sign actually counts as a digit.
+    }
+
+
+    #[test]
+    fn test_count_decimal_digits() {
+        assert_eq!(count_decimal_digits("42"), 0);
+        assert_eq!(count_decimal_digits("12.22"), 2);
+        assert_eq!(count_decimal_digits("1.22"), 2);
+        assert_eq!(count_decimal_digits("1.3"), 1);
+        assert_eq!(count_decimal_digits("1"), 0);
+        assert_eq!(count_decimal_digits("-152.3"), 1);
+    }
+}


### PR DESCRIPTION
The issue #133 was quite hard to fix on the code as is, so I kind of made a major rewrite. The main strategy to prevent the precision issue, which is [used in GNU Seq](https://github.com/coreutils/coreutils/blob/13af84d09aee03971600ecb8918cdb67b1358478/src/seq.c#L324), is to compare the displayed numbers in order to identify if the last one should be printed. The code now adopts the same strategy, by leveraging the Display trait and keeping track of the last displayed number. The separator/terminator is output separately.

- Fix #133
- Improve performance by reducing O(n) allocations to O(1) allocations
- Improve overall code quality

Please let me know if you have any suggestions or concerns.