### PR TITLE
Time: More cleanup

### DIFF
--- a/coreutils_core/src/lib.rs
+++ b/coreutils_core/src/lib.rs
@@ -11,3 +11,4 @@ pub mod input;
 pub mod mkfifo;
 pub mod mktemp;
 pub mod os;
+pub mod strings;

--- a/coreutils_core/src/strings.rs
+++ b/coreutils_core/src/strings.rs
@@ -1,0 +1,76 @@
+//! The strings module handles common string operations on strings from the command-line
+
+/// Wraps a character iterator over a string,
+/// and unescapes escaped ASCII control sequences as it comes across them.
+///
+/// A simple example of this would be rendering escaped newline and tab chars:
+///
+/// ```rust
+/// let s = StringEscapeDecoder::from(&"a\\nb\\tc")
+/// assert_eq!("a\nb\tc", a.collect());
+/// ```
+///
+/// See: https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
+pub struct StringEscapeDecoder<'a> {
+    data: std::iter::Peekable<std::str::Chars<'a>>,
+    min_size: usize,
+    max_size: usize,
+}
+
+/// FIXME: It should be possible to convert this from anything that supports AsRef<str>
+impl<'a> From<&'a str> for StringEscapeDecoder<'a> {
+    fn from(buffer: &'a str) -> Self {
+        let max_escapes = buffer.matches('\\').count();
+        StringEscapeDecoder {
+            data: buffer.chars().peekable(),
+            min_size: buffer.len() - max_escapes,
+            max_size: buffer.len(),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for StringEscapeDecoder<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.data.next() {
+            Some('\\') => {
+                let (consume_next, char_to_emit) = match self.data.peek() {
+                    Some('0') => (true, /* '\0' */ 0x00 as char),
+                    Some('a') => (true, /* '\a' */ 0x07 as char),
+                    Some('b') => (true, /* '\b' */ 0x08 as char),
+                    Some('e') => (true, /* '\e' */ 0x1B as char),
+                    Some('f') => (true, /* '\f' */ 0x0C as char),
+                    Some('n') => (true, '\n'),
+                    Some('r') => (true, '\r'),
+                    Some('t') => (true, '\t'),
+                    Some('v') => (true, /* '\v' */ 0x0B as char),
+                    Some('\\') => (true, '\\'),
+                    Some('\'') => (true, '\''),
+                    Some('"') => (true, '"'),
+                    Some('?') => (true, /* '\?' */ 0x3F as char),
+                    // If the next character isn't a known ASCII escape code,
+                    // or doesn't exist: Return the current '\\'
+                    _ => (false, '\\'),
+                };
+
+                if consume_next {
+                    self.data.next();
+                    self.min_size -= 2;
+                    self.max_size -= 2;
+                } else {
+                    self.min_size -= 1;
+                    self.max_size -= 1;
+                };
+                Some(char_to_emit)
+            },
+            Some(c) => Some(c),
+            None => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.min_size, Some(self.max_size))
+    }
+}
+

--- a/printf/Cargo.toml
+++ b/printf/Cargo.toml
@@ -13,6 +13,7 @@ Uses a template string and arguments to create a formatted output
 
 [dependencies]
 clap = { version = "^2.33.0", features = ["wrap_help"] }
+coreutils_core = { path = "../coreutils_core"}
 
 [build-dependencies]
 clap = "^2.33.0"

--- a/printf/src/main.rs
+++ b/printf/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 use std::{process, result::Result, str::FromStr};
 
 use clap::Values;
+use coreutils_core::strings::StringEscapeDecoder;
 
 const ARG_UNDERFLOW_ERROR: i32 = 64;
 const ARG_UNPARSABLE_ERROR: i32 = 63;
@@ -20,11 +21,8 @@ fn main() {
 }
 
 fn parse_format(format_string: &str, args: Option<Values>) -> Result<String, i32> {
-    let format_string: Vec<char> = format_string.chars().collect();
+    let format_string: Vec<char> = StringEscapeDecoder::from(format_string).collect();
     let mut args = args;
-
-    println!("Format: {:?}", &format_string);
-    println!("Args: {:?}", &args);
 
     let mut parts = vec![];
     let mut chars = vec![];
@@ -32,26 +30,6 @@ fn parse_format(format_string: &str, args: Option<Values>) -> Result<String, i32
 
     while fmt_index < format_string.len() {
         match format_string[fmt_index] {
-            '\\' => {
-                // Escape sequence
-                fmt_index += 1;
-                match format_string[fmt_index] {
-                    'a' => chars.push('\x07'),
-                    'b' => chars.push('\x08'),
-                    'f' => chars.push('\x0C'),
-                    'n' => chars.push('\n'),
-                    'r' => chars.push('\r'),
-                    't' => chars.push('\t'),
-                    'v' => chars.push('\x0D'),
-                    '\'' => chars.push('\''),
-                    '\\' => chars.push('\\'),
-                    _ => {
-                        // Write a byte whose value is the 1-, 2-, or 3-digit octal number
-                        // num.  Multibyte characters can be constructed using multiple
-                        // \num sequences.
-                    },
-                }
-            },
             '%' => {
                 // Format sequence
                 fmt_index += 1;

--- a/time/src/main.rs
+++ b/time/src/main.rs
@@ -17,7 +17,7 @@ fn main() {
     let written = match opts.get_output_stream() {
         Ok(mut stream) => {
             let data = opts.printer.format_stats(&usage, &duration);
-            stream.write(data.as_bytes())
+            stream.write(data.unwrap().as_bytes())
         },
         Err(err) => Err(err),
     };

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -154,6 +154,77 @@ fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: u8) -> Optio
     }
 }
 
+/// Wraps a character iterator over a string,
+/// and unescapes escaped ASCII control sequences as it comes across them.
+///
+/// A simple example of this would be rendering escaped newline and tab chars
+/// ```rust
+/// let s = StringEscapeDecoder::from(&"a\\nb\\tc")
+/// assert_eq!("a\nb\tc", a.collect());
+/// ```
+/// See: https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
+struct StringEscapeDecoder<'a> {
+    data: std::iter::Peekable<std::str::Chars<'a>>,
+    min_size: usize,
+    max_size: usize,
+}
+
+impl<'a> From<&'a str> for StringEscapeDecoder<'a> {
+    fn from(buffer: &'a str) -> Self {
+        let max_escapes = buffer.chars().filter(|&c| c == '\\').count();
+        StringEscapeDecoder {
+            data: buffer.chars().peekable(),
+            min_size: buffer.len() - max_escapes,
+            max_size: buffer.len(),
+        }
+    }
+}
+
+impl<'a> std::iter::Iterator for StringEscapeDecoder<'a> {
+    type Item = char;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.data.next() {
+            Some('\\') => {
+                let (consume_next, char_to_emit) = match self.data.peek() {
+                    Some('0') => (true, /* '\0' */ 0x00 as char),
+                    Some('a') => (true, /* '\a' */ 0x07 as char),
+                    Some('b') => (true, /* '\b' */ 0x08 as char),
+                    Some('e') => (true, /* '\e' */ 0x1B as char),
+                    Some('f') => (true, /* '\f' */ 0x0C as char),
+                    Some('n') => (true, '\n'),
+                    Some('r') => (true, '\r'),
+                    Some('t') => (true, '\t'),
+                    Some('v') => (true, /* '\v' */ 0x0B as char),
+                    Some('\\') => (true, '\\'),
+                    Some('\'') => (true, '\''),
+                    Some('"') => (true, '"'),
+                    Some('?') => (true, /* '\?' */ 0x3F as char),
+                    // If the next character isn't a known ASCII escape code,
+                    // or doesn't exist: Return the current '\\'
+                    _ => (false, '\\'),
+                };
+
+                if consume_next {
+                    self.data.next();
+                    self.min_size -= 2;
+                    self.max_size -= 2;
+                } else {
+                    self.min_size -= 1;
+                    self.max_size -= 1;
+                };
+                Some(char_to_emit)
+            },
+            Some(c) => Some(c),
+            None => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.min_size, Some(self.max_size))
+    }
+}
+
 /// Internal: Unescapes a backslash escaped string
 /// See: https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
 fn decode_escaped_string(value: String) -> String {

--- a/time/src/output.rs
+++ b/time/src/output.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use coreutils_core::{os::resource::RUsage, time::Duration};
+use coreutils_core::{os::resource::RUsage, strings::StringEscapeDecoder, time::Duration};
 
 /// The `FormatterKind` enum is how `time` controls the printing
 /// of timing and resource usage information
@@ -149,79 +149,6 @@ fn render_percent_spec(rusage: &RUsage, timings: &TimeTriple, spec: char) -> Opt
         'w' => Some(rusage.mem.num_vol_ctx_switch.to_string()),
         'X' => Some(rusage.mem.shared_mem_size.to_string()),
         _ => None,
-    }
-}
-
-/// Wraps a character iterator over a string,
-/// and unescapes escaped ASCII control sequences as it comes across them.
-///
-/// A simple example of this would be rendering escaped newline and tab chars:
-///
-/// ```rust
-/// let s = StringEscapeDecoder::from(&"a\\nb\\tc")
-/// assert_eq!("a\nb\tc", a.collect());
-/// ```
-///
-/// See: https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences
-struct StringEscapeDecoder<'a> {
-    data: std::iter::Peekable<std::str::Chars<'a>>,
-    min_size: usize,
-    max_size: usize,
-}
-
-impl<'a> From<&'a str> for StringEscapeDecoder<'a> {
-    fn from(buffer: &'a str) -> Self {
-        let max_escapes = buffer.chars().filter(|&c| c == '\\').count();
-        StringEscapeDecoder {
-            data: buffer.chars().peekable(),
-            min_size: buffer.len() - max_escapes,
-            max_size: buffer.len(),
-        }
-    }
-}
-
-impl<'a> std::iter::Iterator for StringEscapeDecoder<'a> {
-    type Item = char;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self.data.next() {
-            Some('\\') => {
-                let (consume_next, char_to_emit) = match self.data.peek() {
-                    Some('0') => (true, /* '\0' */ 0x00 as char),
-                    Some('a') => (true, /* '\a' */ 0x07 as char),
-                    Some('b') => (true, /* '\b' */ 0x08 as char),
-                    Some('e') => (true, /* '\e' */ 0x1B as char),
-                    Some('f') => (true, /* '\f' */ 0x0C as char),
-                    Some('n') => (true, '\n'),
-                    Some('r') => (true, '\r'),
-                    Some('t') => (true, '\t'),
-                    Some('v') => (true, /* '\v' */ 0x0B as char),
-                    Some('\\') => (true, '\\'),
-                    Some('\'') => (true, '\''),
-                    Some('"') => (true, '"'),
-                    Some('?') => (true, /* '\?' */ 0x3F as char),
-                    // If the next character isn't a known ASCII escape code,
-                    // or doesn't exist: Return the current '\\'
-                    _ => (false, '\\'),
-                };
-
-                if consume_next {
-                    self.data.next();
-                    self.min_size -= 2;
-                    self.max_size -= 2;
-                } else {
-                    self.min_size -= 1;
-                    self.max_size -= 1;
-                };
-                Some(char_to_emit)
-            },
-            Some(c) => Some(c),
-            None => None,
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.min_size, Some(self.max_size))
     }
 }
 


### PR DESCRIPTION
* Introduce `StringEscapeDecoder` which wraps a string iterator that unescapes ASCII control codes in the underlying string
* Make the `x_formatter` functions return an `Option<String>` for when they are unable to format the rusage struct.
  - [ ] Still calling `unwrap()` at the top level. Could probably add my own wrapper enum if that is a huge concern

@GrayJack Do you think we can use `StringEscapeDecoder` somewhere else in this project?
